### PR TITLE
fix content type in response error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - github.com/elliotchance/pie dependency
 
+### Fixed
+
+- improved tests to use w.Result() to assert the correct response
+- fix response `Content-Type` when an error occurs
+
 ## 1.3.1 - 21-07-2022
 
 ### Fixed

--- a/handler.go
+++ b/handler.go
@@ -120,8 +120,8 @@ func EvaluateRequest(req *http.Request, env config.EnvironmentVariables, w http.
 	_, query, err := evaluatorAllowPolicy.PolicyEvaluation(logger, permission)
 	if err != nil {
 		if errors.Is(err, opatranslator.ErrEmptyQuery) && hasApplicationJSONContentType(req.Header) {
-			w.WriteHeader(http.StatusOK)
 			w.Header().Set(ContentTypeHeaderKey, JSONContentTypeHeader)
+			w.WriteHeader(http.StatusOK)
 			if _, err := w.Write([]byte("[]")); err != nil {
 				logger.WithField("error", logrus.Fields{"message": err.Error()}).Warn("failed response write")
 				return err

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -43,7 +43,7 @@ func TestRequestMiddlewareEnvironments(t *testing.T) {
 		r := httptest.NewRequest(http.MethodGet, "/", nil)
 		builtHandler.ServeHTTP(w, r)
 
-		assert.Equal(t, w.Code, http.StatusOK, "Unexpected status code.")
+		assert.Equal(t, w.Result().StatusCode, http.StatusOK, "Unexpected status code.")
 	})
 }
 

--- a/internal/mongoclient/mongoclient_test.go
+++ b/internal/mongoclient/mongoclient_test.go
@@ -54,7 +54,7 @@ func TestMongoCollectionInjectorMiddleware(t *testing.T) {
 
 		builtMiddleware.ServeHTTP(w, r)
 
-		assert.Equal(t, w.Code, http.StatusOK, "Unexpected status code")
+		assert.Equal(t, w.Result().StatusCode, http.StatusOK, "Unexpected status code")
 		assert.Assert(t, invoked, "Next middleware not invoked")
 	})
 }

--- a/main_test.go
+++ b/main_test.go
@@ -27,11 +27,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mia-platform/glogger/v2"
 	"github.com/rond-authz/rond/internal/config"
 	"github.com/rond-authz/rond/internal/mongoclient"
 	"github.com/rond-authz/rond/internal/testutils"
 	"github.com/rond-authz/rond/types"
 
+	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -67,6 +69,7 @@ func TestProxyOASPath(t *testing.T) {
 			{name: "TARGET_SERVICE_HOST", value: "localhost:3001"},
 			{name: "TARGET_SERVICE_OAS_PATH", value: "/custom/documentation/json"},
 			{name: "OPA_MODULES_DIRECTORY", value: "./mocks/rego-policies"},
+			{name: "LOG_LEVEL", value: "fatal"},
 		})
 
 		go func() {
@@ -83,7 +86,6 @@ func TestProxyOASPath(t *testing.T) {
 		require.Equal(t, nil, err, "error calling docs")
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 		require.True(t, gock.IsDone(), "the proxy does not blocks the request for documentations path.")
-
 	})
 
 	t.Run("200 - with oas documentation api defined", func(t *testing.T) {
@@ -111,6 +113,7 @@ func TestProxyOASPath(t *testing.T) {
 			{name: "TARGET_SERVICE_HOST", value: "localhost:3006"},
 			{name: "TARGET_SERVICE_OAS_PATH", value: "/documentation/json"},
 			{name: "OPA_MODULES_DIRECTORY", value: "./mocks/rego-policies"},
+			{name: "LOG_LEVEL", value: "fatal"},
 		})
 		go func() {
 			entrypoint(shutdown)
@@ -153,6 +156,7 @@ func TestProxyOASPath(t *testing.T) {
 			{name: "TARGET_SERVICE_HOST", value: "localhost:3008"},
 			{name: "TARGET_SERVICE_OAS_PATH", value: "/documentation/json"},
 			{name: "OPA_MODULES_DIRECTORY", value: "./mocks/rego-policies"},
+			{name: "LOG_LEVEL", value: "fatal"},
 		})
 		go func() {
 			entrypoint(shutdown)
@@ -177,6 +181,7 @@ func TestEntrypoint(t *testing.T) {
 			{name: "TARGET_SERVICE_HOST", value: "localhost:3001"},
 			{name: "TARGET_SERVICE_OAS_PATH", value: "/documentation/json"},
 			{name: "OPA_MODULES_DIRECTORY", value: "./mocks/empty-dir"},
+			{name: "LOG_LEVEL", value: "fatal"},
 		})
 		shutdown := make(chan os.Signal, 1)
 
@@ -204,6 +209,7 @@ func TestEntrypoint(t *testing.T) {
 			{name: "TARGET_SERVICE_HOST", value: "localhost:3001"},
 			{name: "TARGET_SERVICE_OAS_PATH", value: "/documentation/json"},
 			{name: "OPA_MODULES_DIRECTORY", value: "./mocks/rego-policies"},
+			{name: "LOG_LEVEL", value: "fatal"},
 		})
 
 		go func() {
@@ -234,6 +240,7 @@ func TestEntrypoint(t *testing.T) {
 			{name: "TARGET_SERVICE_OAS_PATH", value: "/documentation/json"},
 			{name: "DELAY_SHUTDOWN_SECONDS", value: "3"},
 			{name: "OPA_MODULES_DIRECTORY", value: "./mocks/rego-policies"},
+			{name: "LOG_LEVEL", value: "fatal"},
 		})
 		shutdown := make(chan os.Signal, 1)
 		done := make(chan bool, 1)
@@ -281,6 +288,7 @@ func TestEntrypoint(t *testing.T) {
 			{name: "TARGET_SERVICE_HOST", value: "localhost:3001"},
 			{name: "TARGET_SERVICE_OAS_PATH", value: "/documentation/json"},
 			{name: "OPA_MODULES_DIRECTORY", value: "./mocks/rego-policies"},
+			{name: "LOG_LEVEL", value: "fatal"},
 		})
 
 		go func() {
@@ -340,7 +348,7 @@ func TestEntrypoint(t *testing.T) {
 
 		unsetEnvs := setEnvs([]env{
 			{name: "HTTP_PORT", value: "3026"},
-			{name: "LOG_LEVEL", value: "trace"},
+			{name: "LOG_LEVEL", value: "fatal"},
 			{name: "TARGET_SERVICE_HOST", value: "localhost:3001"},
 			{name: "TARGET_SERVICE_OAS_PATH", value: "/documentation/json"},
 			{name: "OPA_MODULES_DIRECTORY", value: "./mocks/rego-policies"},
@@ -393,6 +401,7 @@ func TestEntrypoint(t *testing.T) {
 			{name: "TARGET_SERVICE_HOST", value: "localhost:3004"},
 			{name: "TARGET_SERVICE_OAS_PATH", value: "/documentation/json"},
 			{name: "OPA_MODULES_DIRECTORY", value: "./mocks/rego-policies"},
+			{name: "LOG_LEVEL", value: "fatal"},
 		})
 
 		go func() {
@@ -437,6 +446,7 @@ func TestEntrypoint(t *testing.T) {
 			{name: "TARGET_SERVICE_HOST", value: "localhost:4000"},
 			{name: "API_PERMISSIONS_FILE_PATH", value: "./mocks/nestedPathsConfig.json"},
 			{name: "OPA_MODULES_DIRECTORY", value: "./mocks/rego-policies"},
+			{name: "LOG_LEVEL", value: "fatal"},
 		})
 
 		go func() {
@@ -485,6 +495,7 @@ func TestEntrypoint(t *testing.T) {
 			{name: "TARGET_SERVICE_HOST", value: "localhost:6000"},
 			{name: "API_PERMISSIONS_FILE_PATH", value: "./mocks/mockForEncodedTest.json"},
 			{name: "OPA_MODULES_DIRECTORY", value: "./mocks/rego-policies"},
+			{name: "LOG_LEVEL", value: "fatal"},
 		})
 
 		go func() {
@@ -530,10 +541,10 @@ func TestEntrypoint(t *testing.T) {
 
 		unsetEnvs := setEnvs([]env{
 			{name: "HTTP_PORT", value: "5555"},
-			{name: "LOG_LEVEL", value: "trace"},
 			{name: "TARGET_SERVICE_HOST", value: "localhost:6000"},
 			{name: "API_PERMISSIONS_FILE_PATH", value: "./mocks/mockForEncodedTest.json"},
 			{name: "OPA_MODULES_DIRECTORY", value: "./mocks/rego-policies"},
+			{name: "LOG_LEVEL", value: "fatal"},
 		})
 
 		go func() {
@@ -579,10 +590,10 @@ func TestEntrypoint(t *testing.T) {
 
 		unsetEnvs := setEnvs([]env{
 			{name: "HTTP_PORT", value: "5555"},
-			{name: "LOG_LEVEL", value: "trace"},
 			{name: "TARGET_SERVICE_HOST", value: "localhost:6000"},
 			{name: "API_PERMISSIONS_FILE_PATH", value: "./mocks/mockForEncodedTest.json"},
 			{name: "OPA_MODULES_DIRECTORY", value: "./mocks/rego-policies"},
+			{name: "LOG_LEVEL", value: "fatal"},
 		})
 
 		go func() {
@@ -648,6 +659,7 @@ func TestEntrypoint(t *testing.T) {
 			{name: "MONGODB_URL", value: fmt.Sprintf("mongodb://%s/%s", mongoHost, mongoDBName)},
 			{name: "BINDINGS_COLLECTION_NAME", value: "bindings"},
 			{name: "ROLES_COLLECTION_NAME", value: "roles"},
+			{name: "LOG_LEVEL", value: "fatal"},
 		})
 
 		clientOpts := options.Client().ApplyURI(fmt.Sprintf("mongodb://%s", mongoHost))
@@ -819,6 +831,7 @@ func TestEntrypoint(t *testing.T) {
 			{name: "TARGET_SERVICE_HOST", value: "localhost:3033"},
 			{name: "TARGET_SERVICE_OAS_PATH", value: "/documentation/json"},
 			{name: "OPA_MODULES_DIRECTORY", value: "./mocks/rego-policies"},
+			{name: "LOG_LEVEL", value: "fatal"},
 		})
 		mongoHost := os.Getenv("MONGO_HOST_CI")
 		if mongoHost == "" {
@@ -832,6 +845,7 @@ func TestEntrypoint(t *testing.T) {
 			{name: "MONGODB_URL", value: fmt.Sprintf("mongodb://%s/%s", mongoHost, mongoDBName)},
 			{name: "BINDINGS_COLLECTION_NAME", value: "bindings"},
 			{name: "ROLES_COLLECTION_NAME", value: "roles"},
+			{name: "LOG_LEVEL", value: "fatal"},
 		})
 
 		clientOpts := options.Client().ApplyURI(fmt.Sprintf("mongodb://%s", mongoHost))
@@ -906,6 +920,7 @@ func TestEntrypoint(t *testing.T) {
 			{name: "TARGET_SERVICE_HOST", value: "localhost:3035"},
 			{name: "TARGET_SERVICE_OAS_PATH", value: "/documentation/json"},
 			{name: "OPA_MODULES_DIRECTORY", value: "./mocks/rego-policies"},
+			{name: "LOG_LEVEL", value: "fatal"},
 		})
 		mongoHost := os.Getenv("MONGO_HOST_CI")
 		if mongoHost == "" {
@@ -919,6 +934,7 @@ func TestEntrypoint(t *testing.T) {
 			{name: "MONGODB_URL", value: fmt.Sprintf("mongodb://%s/%s", mongoHost, mongoDBName)},
 			{name: "BINDINGS_COLLECTION_NAME", value: "bindings"},
 			{name: "ROLES_COLLECTION_NAME", value: "roles"},
+			{name: "LOG_LEVEL", value: "fatal"},
 		})
 
 		clientOpts := options.Client().ApplyURI(fmt.Sprintf("mongodb://%s", mongoHost))
@@ -965,7 +981,6 @@ func TestEntrypoint(t *testing.T) {
 }
 
 func TestEntrypointWithResponseFiltering(t *testing.T) {
-
 	shutdown := make(chan os.Signal, 1)
 
 	defer gock.Off()
@@ -998,6 +1013,7 @@ func TestEntrypointWithResponseFiltering(t *testing.T) {
 		{name: "TARGET_SERVICE_HOST", value: "localhost:3040"},
 		{name: "TARGET_SERVICE_OAS_PATH", value: "/documentation/json"},
 		{name: "OPA_MODULES_DIRECTORY", value: "./mocks/rego-policies"},
+		{name: "LOG_LEVEL", value: "fatal"},
 	})
 	mongoHost := os.Getenv("MONGO_HOST_CI")
 	if mongoHost == "" {
@@ -1011,6 +1027,7 @@ func TestEntrypointWithResponseFiltering(t *testing.T) {
 		{name: "MONGODB_URL", value: fmt.Sprintf("mongodb://%s/%s", mongoHost, mongoDBName)},
 		{name: "BINDINGS_COLLECTION_NAME", value: "bindings"},
 		{name: "ROLES_COLLECTION_NAME", value: "roles"},
+		{name: "LOG_LEVEL", value: "fatal"},
 	})
 
 	clientOpts := options.Client().ApplyURI(fmt.Sprintf("mongodb://%s", mongoHost))
@@ -1138,6 +1155,7 @@ func TestIntegrationWithOASParamsInBrackets(t *testing.T) {
 		{name: "TARGET_SERVICE_HOST", value: "localhost:3050"},
 		{name: "TARGET_SERVICE_OAS_PATH", value: "/documentation/json"},
 		{name: "OPA_MODULES_DIRECTORY", value: "./mocks/rego-policies"},
+		{name: "LOG_LEVEL", value: "fatal"},
 	})
 	mongoHost := os.Getenv("MONGO_HOST_CI")
 	if mongoHost == "" {
@@ -1151,6 +1169,7 @@ func TestIntegrationWithOASParamsInBrackets(t *testing.T) {
 		{name: "MONGODB_URL", value: fmt.Sprintf("mongodb://%s/%s", mongoHost, mongoDBName)},
 		{name: "BINDINGS_COLLECTION_NAME", value: "bindings"},
 		{name: "ROLES_COLLECTION_NAME", value: "roles"},
+		{name: "LOG_LEVEL", value: "fatal"},
 	})
 
 	clientOpts := options.Client().ApplyURI(fmt.Sprintf("mongodb://%s", mongoHost))
@@ -1208,6 +1227,8 @@ func TestSetupRouterStandaloneMode(t *testing.T) {
 	defer gock.Flush()
 
 	log, _ := test.NewNullLogger()
+	ctx := glogger.WithLogger(context.Background(), logrus.NewEntry(log))
+
 	env := config.EnvironmentVariables{
 		Standalone:           true,
 		TargetServiceHost:    "my-service:4444",
@@ -1232,7 +1253,7 @@ test_policy { true }
 	}
 
 	var mongoClient *mongoclient.MongoClient
-	evaluatorsMap, err := setupEvaluators(context.TODO(), mongoClient, oas, opa, env)
+	evaluatorsMap, err := setupEvaluators(ctx, mongoClient, oas, opa, env)
 	assert.NilError(t, err, "unexpected error")
 
 	router, err := setupRouter(log, env, opa, oas, evaluatorsMap, mongoClient)

--- a/opaevaluator_test.go
+++ b/opaevaluator_test.go
@@ -125,6 +125,8 @@ func TestCreateRegoInput(t *testing.T) {
 func TestCreatePolicyEvaluators(t *testing.T) {
 	t.Run("with simplified mock", func(t *testing.T) {
 		log, _ := test.NewNullLogger()
+		ctx := glogger.WithLogger(context.Background(), logrus.NewEntry(log))
+
 		envs := config.EnvironmentVariables{
 			APIPermissionsFilePath: "./mocks/simplifiedMock.json",
 			OPAModulesDirectory:    "./mocks/rego-policies",
@@ -135,7 +137,7 @@ func TestCreatePolicyEvaluators(t *testing.T) {
 		opaModuleConfig, err := loadRegoModule(envs.OPAModulesDirectory)
 		assert.Assert(t, err == nil, "unexpected error")
 
-		policyEvals, err := setupEvaluators(context.Background(), nil, openApiSpec, opaModuleConfig, envs)
+		policyEvals, err := setupEvaluators(ctx, nil, openApiSpec, opaModuleConfig, envs)
 		assert.Assert(t, err == nil, "unexpected error creating evaluators")
 		assert.Equal(t, len(policyEvals), 4, "unexpected length")
 	})

--- a/openapi_utils.go
+++ b/openapi_utils.go
@@ -17,6 +17,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -35,6 +36,8 @@ import (
 )
 
 const ALL_METHODS = "ALL"
+
+var ErrNotFoundOASDefinition = errors.New("not found oas definition")
 
 type XPermissionKey struct{}
 
@@ -191,7 +194,7 @@ func (oas *OpenAPISpec) FindPermission(OASRouter *bunrouter.CompatRouter, path s
 	OASRouter.ServeHTTP(recorder, request)
 
 	if recorder.Code != http.StatusOK {
-		return XPermission{}, fmt.Errorf("not found oas permission: %s %s", utils.SanitizeString(method), utils.SanitizeString(path))
+		return XPermission{}, fmt.Errorf("%w: %s %s", ErrNotFoundOASDefinition, utils.SanitizeString(method), utils.SanitizeString(path))
 	}
 
 	recorderResult := recorder.Result()

--- a/openapi_utils_test.go
+++ b/openapi_utils_test.go
@@ -280,15 +280,15 @@ func TestFindPermission(t *testing.T) {
 
 		found, err := oas.FindPermission(OASRouter, "/not/existing/route", "GET")
 		assert.Equal(t, XPermission{}, found)
-		assert.Equal(t, err.Error(), "not found oas permission: GET /not/existing/route")
+		assert.Equal(t, err.Error(), fmt.Sprintf("%s: GET /not/existing/route", ErrNotFoundOASDefinition))
 
 		found, err = oas.FindPermission(OASRouter, "/no/method", "PUT")
 		assert.Equal(t, XPermission{}, found)
-		assert.Equal(t, err.Error(), "not found oas permission: PUT /no/method")
+		assert.Equal(t, err.Error(), fmt.Sprintf("%s: PUT /no/method", ErrNotFoundOASDefinition))
 
 		found, err = oas.FindPermission(OASRouter, "/use/method/that/not/existing/put", "PUT")
 		assert.Equal(t, XPermission{}, found)
-		assert.Equal(t, err.Error(), "not found oas permission: PUT /use/method/that/not/existing/put")
+		assert.Equal(t, err.Error(), fmt.Sprintf("%s: PUT /use/method/that/not/existing/put", ErrNotFoundOASDefinition))
 
 		found, err = oas.FindPermission(OASRouter, "/foo/bar/barId", "GET")
 		assert.Equal(t, XPermission{
@@ -340,7 +340,7 @@ func TestFindPermission(t *testing.T) {
 
 		found, err = oas.FindPermission(OASRouter, "/test/all", "GET")
 		assert.Equal(t, XPermission{}, found)
-		assert.Equal(t, err.Error(), "not found oas permission: GET /test/all")
+		assert.Equal(t, err.Error(), fmt.Sprintf("%s: GET /test/all", ErrNotFoundOASDefinition))
 
 		found, err = oas.FindPermission(OASRouter, "/test/all/", "GET")
 		assert.Equal(t, XPermission{AllowPermission: "permission_for_get"}, found)

--- a/router_test.go
+++ b/router_test.go
@@ -208,6 +208,9 @@ func createContext(
 	}
 	partialContext = context.WithValue(partialContext, PartialResultsEvaluatorConfigKey{}, partialResultEvaluators)
 
+	log, _ := test.NewNullLogger()
+	partialContext = glogger.WithLogger(partialContext, logrus.NewEntry(log))
+
 	return partialContext
 }
 

--- a/router_test.go
+++ b/router_test.go
@@ -24,9 +24,12 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/mia-platform/glogger/v2"
 	"github.com/rond-authz/rond/internal/config"
 	"github.com/rond-authz/rond/internal/mocks"
 	"github.com/rond-authz/rond/types"
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
 
 	"github.com/gorilla/mux"
 	"gotest.tools/v3/assert"
@@ -217,7 +220,11 @@ var mockXPermission = &XPermission{AllowPermission: "todo"}
 
 func TestSetupRoutesIntegration(t *testing.T) {
 	oas := prepareOASFromFile(t, "./mocks/simplifiedMock.json")
-	mockPartialEvaluators, _ := setupEvaluators(context.Background(), nil, oas, mockOPAModule, envs)
+
+	log, _ := test.NewNullLogger()
+	ctx := glogger.WithLogger(context.Background(), logrus.NewEntry(log))
+
+	mockPartialEvaluators, _ := setupEvaluators(ctx, nil, oas, mockOPAModule, envs)
 	t.Run("invokes known API", func(t *testing.T) {
 		var invoked bool
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -298,12 +305,12 @@ func TestSetupRoutesIntegration(t *testing.T) {
 			Content: `package policies
 		todo { false }`,
 		}
-		mockPartialEvaluators, _ := setupEvaluators(context.Background(), nil, oas, mockOPAModule, envs)
+		mockPartialEvaluators, _ := setupEvaluators(ctx, nil, oas, mockOPAModule, envs)
 		router := mux.NewRouter()
 		setupRoutes(router, oas, envs)
 
 		ctx := createContext(t,
-			context.Background(),
+			ctx,
 			config.EnvironmentVariables{LogLevel: "silent", TargetServiceHost: "targetServiceHostWillNotBeInvoked"},
 			nil,
 			mockXPermission,
@@ -329,7 +336,7 @@ func TestSetupRoutesIntegration(t *testing.T) {
 		var mockOPAModule = &OPAModuleConfig{
 			Content: "FAILING POLICY!!!!",
 		}
-		mockPartialEvaluators, _ := setupEvaluators(context.Background(), nil, oas, mockOPAModule, envs)
+		mockPartialEvaluators, _ := setupEvaluators(ctx, nil, oas, mockOPAModule, envs)
 
 		router := mux.NewRouter()
 		setupRoutes(router, oas, envs)

--- a/statusroutes.go
+++ b/statusroutes.go
@@ -31,7 +31,7 @@ type StatusResponse struct {
 }
 
 func handleStatusRoutes(w http.ResponseWriter, serviceName, serviceVersion string) (*StatusResponse, []byte) {
-	w.Header().Add(ContentTypeHeaderKey, "application/json")
+	w.Header().Add(ContentTypeHeaderKey, JSONContentTypeHeader)
 	status := StatusResponse{
 		Status:  "OK",
 		Name:    serviceName,

--- a/statusroutes_test.go
+++ b/statusroutes_test.go
@@ -22,10 +22,12 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/mia-platform/glogger/v2"
 	"github.com/rond-authz/rond/internal/config"
 	"github.com/rond-authz/rond/internal/mongoclient"
 
 	"github.com/gorilla/mux"
+	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
 	"gotest.tools/v3/assert"
@@ -88,6 +90,8 @@ func TestStatusRoutes(testCase *testing.T) {
 
 func TestStatusRoutesIntegration(t *testing.T) {
 	log, _ := test.NewNullLogger()
+	ctx := glogger.WithLogger(context.Background(), logrus.NewEntry(log))
+
 	opa := &OPAModuleConfig{
 		Name: "policies",
 		Content: `package policies
@@ -107,7 +111,7 @@ test_policy { true }
 	}
 
 	var mongoClient *mongoclient.MongoClient
-	evaluatorsMap, err := setupEvaluators(context.TODO(), mongoClient, oas, opa, envs)
+	evaluatorsMap, err := setupEvaluators(ctx, mongoClient, oas, opa, envs)
 	assert.NilError(t, err, "unexpected error")
 
 	t.Run("non standalone", func(t *testing.T) {

--- a/utilities.go
+++ b/utilities.go
@@ -34,6 +34,7 @@ func failResponse(w http.ResponseWriter, technicalError, businessError string) {
 }
 
 func failResponseWithCode(w http.ResponseWriter, statusCode int, technicalError, businessError string) {
+	w.Header().Set(ContentTypeHeaderKey, JSONContentTypeHeader)
 	w.WriteHeader(statusCode)
 	content, err := json.Marshal(types.RequestError{
 		StatusCode: statusCode,
@@ -44,7 +45,6 @@ func failResponseWithCode(w http.ResponseWriter, statusCode int, technicalError,
 		return
 	}
 
-	w.Header().Set(ContentTypeHeaderKey, JSONContentTypeHeader)
 	//#nosec G104 -- Intended to avoid disruptive code changes
 	w.Write(content)
 }

--- a/utilities_test.go
+++ b/utilities_test.go
@@ -71,9 +71,9 @@ func TestFailResponseWithCode(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	failResponseWithCode(w, http.StatusInternalServerError, "The Error", "The Message")
-	assert.Equal(t, w.Code, http.StatusInternalServerError)
+	assert.Equal(t, w.Result().StatusCode, http.StatusInternalServerError)
 
-	assert.Equal(t, w.Header().Get(ContentTypeHeaderKey), "application/json")
+	assert.Equal(t, w.Result().Header.Get(ContentTypeHeaderKey), JSONContentTypeHeader)
 
 	bodyBytes, err := ioutil.ReadAll(w.Body)
 	assert.NilError(t, err)


### PR DESCRIPTION
I made the following changes:

- improved tests to use w.Result() to assert the correct response. Without the use of `w.Result()`, it is tested the value set in the ResponseRecorder and not the value returned. For example, the set of the content-type header after the WriteHeader method does not set the header in the response.
- fix response `Content-Type` when an error occurs: move set of header before the WriteHeader
- remove unnecessary service logs when tests run