### PR TITLE
generate automatic release on tag

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,20 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - breaking
+    - title: Exciting New Features 🎉
+      labels:
+        - enhancement
+    - title: Bug fixes 🎉
+      labels:
+        - bug
+    - title: Security Fixes 🔐
+      labels:
+        - security
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,16 @@
+name: Release
+on:
+  push:
+    tags:
+      - '*'
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          generate_release_notes: true
+          prerelease: ${{ startsWith(github.ref, 'refs/tags/') && contains(github.ref, '-rc.') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+> ⚠ This file is deprecated. Releases after 3.0.0 use GitHub's built-in releases to track changes ⚠
+
 # CHANGELOG
 
 All notable changes to this project will be documented in this file.


### PR DESCRIPTION
I deprecated the CHANGELOG.md file, from my point of view it could also be removed since previous releases are already existent (but not all from 0.1.0 release, so I only deprecate it). What do you think?

Please keep attention: for each new PR, it is important to set the correct label to correctly address the release note.