### PR TITLE
feat: add evaluation info logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+
+- add completed evaluation logs at info level
+
 ## 1.5.0 - 19-10-2022
 
 ## 1.4.3 - 12-10-2022

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
-### Added
-
-- add completed evaluation logs at info level
-
 ## 1.5.0 - 19-10-2022
 
 ## 1.4.3 - 12-10-2022

--- a/handler_test.go
+++ b/handler_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/rond-authz/rond/internal/mongoclient"
 	"github.com/rond-authz/rond/internal/testutils"
 	"github.com/rond-authz/rond/types"
-	"github.com/stretchr/testify/require"
 
 	"github.com/gorilla/mux"
 	"github.com/mia-platform/glogger/v2"
@@ -42,6 +41,7 @@ import (
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
 	"gotest.tools/v3/assert"
 )
 

--- a/router_test.go
+++ b/router_test.go
@@ -209,6 +209,12 @@ func createContext(
 	log, _ := test.NewNullLogger()
 	partialContext = glogger.WithLogger(partialContext, logrus.NewEntry(log))
 
+	partialContext = context.WithValue(partialContext, RouterInfoKey{}, RouterInfo{
+		MatchedPath:   "/matched/path",
+		RequestedPath: "/requested/path",
+		Method:        "GET",
+	})
+
 	return partialContext
 }
 


### PR DESCRIPTION
In this PR I add info logs at every policy evaluated complete with info about the policy, the path and the handler.
This bring to have 1 more line of log for every call if service is at info level. It can be ok to set this log at debug level, what do you think?
Maybe we could change it to debug when we expose some custom metrics