### PR TITLE
Expose metrics endpoint

### DIFF
--- a/internal/metrics/routes.go
+++ b/internal/metrics/routes.go
@@ -10,8 +10,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
+var MetricsRoutePath = "/-/rond/metrics"
+
 func MetricsRoute(r *mux.Router, registry *prometheus.Registry) {
-	r.Handle("/metrics", promhttp.InstrumentMetricHandler(
+	r.Handle(MetricsRoutePath, promhttp.InstrumentMetricHandler(
 		registry,
 		promhttp.HandlerFor(registry, promhttp.HandlerOpts{
 			Registry:          registry,

--- a/internal/utils/general.go
+++ b/internal/utils/general.go
@@ -32,3 +32,5 @@ func SanitizeString(input string) string {
 	sanitized = strings.Replace(sanitized, "\r", "", -1)
 	return sanitized
 }
+
+var Union = lo.Union[string]

--- a/main_test.go
+++ b/main_test.go
@@ -1862,7 +1862,7 @@ filter_policy {
 
 	t.Run("metrics API exposed correctly", func(t *testing.T) {
 		w := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+		req := httptest.NewRequest(http.MethodGet, "/-/rond/metrics", nil)
 		router.ServeHTTP(w, req)
 
 		require.Equal(t, http.StatusOK, w.Result().StatusCode)

--- a/opamiddleware.go
+++ b/opamiddleware.go
@@ -49,7 +49,7 @@ func OPAMiddleware(opaModuleConfig *OPAModuleConfig, openAPISpec *OpenAPISpec, e
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if utils.Contains(statusRoutes, r.URL.RequestURI()) {
+			if utils.Contains(routesToNotProxy, r.URL.RequestURI()) {
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/router.go
+++ b/router.go
@@ -24,11 +24,14 @@ import (
 
 	swagger "github.com/davidebianchi/gswagger"
 	"github.com/rond-authz/rond/internal/config"
+	"github.com/rond-authz/rond/internal/metrics"
 	"github.com/rond-authz/rond/internal/utils"
 	"github.com/rond-authz/rond/types"
 
 	"github.com/gorilla/mux"
 )
+
+var routesToNotProxy = utils.Union(statusRoutes, []string{metrics.MetricsRoutePath})
 
 var revokeDefinitions = swagger.Definitions{
 	RequestBody: &swagger.ContentValue{
@@ -135,7 +138,7 @@ func setupRoutes(router *mux.Router, oas *OpenAPISpec, env config.EnvironmentVar
 		if env.Standalone {
 			pathToRegister = fmt.Sprintf("%s%s", env.PathPrefixStandalone, path)
 		}
-		if utils.Contains(statusRoutes, pathToRegister) {
+		if utils.Contains(routesToNotProxy, pathToRegister) {
 			continue
 		}
 		if strings.Contains(pathToRegister, "*") {

--- a/router_test.go
+++ b/router_test.go
@@ -48,9 +48,10 @@ func TestSetupRoutes(t *testing.T) {
 				"/-/ready":    PathVerbs{},
 				"/-/healthz":  PathVerbs{},
 				"/-/check-up": PathVerbs{},
+				"/-/metrics":  PathVerbs{},
 			},
 		}
-		expectedPaths := []string{"/", "/-/check-up", "/-/healthz", "/-/ready", "/bar", "/documentation/json", "/foo", "/foo/bar"}
+		expectedPaths := []string{"/", "/-/check-up", "/-/healthz", "/-/metrics", "/-/ready", "/bar", "/documentation/json", "/foo", "/foo/bar"}
 
 		setupRoutes(router, oas, envs)
 
@@ -456,6 +457,10 @@ func TestSetupRoutesIntegration(t *testing.T) {
 		require.True(t, invoked, "mock server was not invoked")
 		require.Equal(t, http.StatusOK, w.Result().StatusCode)
 	})
+}
+
+func TestRoutesToNotProxy(t *testing.T) {
+	require.Equal(t, routesToNotProxy, []string{"/-/rbac-healthz", "/-/rbac-ready", "/-/rbac-check-up", "/-/rond/metrics"})
 }
 
 func prepareOASFromFile(t *testing.T, filePath string) *OpenAPISpec {


### PR DESCRIPTION
This PR fixes the case when the proxied services already exposes a metrics endpoint and skip the proxy of this endpoint