### PR TITLE
Add new bucket to metrics

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -15,7 +15,7 @@ func SetupMetrics(prefix string) Metrics {
 			Namespace: prefix,
 			Name:      "policy_evaluation_duration_milliseconds",
 			Help:      "A histogram of the policy evaluation durations in milliseconds.",
-			Buckets:   []float64{1, 5, 10, 50, 100},
+			Buckets:   []float64{1, 5, 10, 50, 100, 250, 500},
 		}, []string{"policy_name"}),
 	}
 

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -28,6 +28,8 @@ func TestMetrics(t *testing.T) {
 			test_prefix_policy_evaluation_duration_milliseconds_bucket{policy_name="myPolicyName",le="10"} 1
 			test_prefix_policy_evaluation_duration_milliseconds_bucket{policy_name="myPolicyName",le="50"} 1
 			test_prefix_policy_evaluation_duration_milliseconds_bucket{policy_name="myPolicyName",le="100"} 1
+			test_prefix_policy_evaluation_duration_milliseconds_bucket{policy_name="myPolicyName",le="250"} 1
+			test_prefix_policy_evaluation_duration_milliseconds_bucket{policy_name="myPolicyName",le="500"} 1
 			test_prefix_policy_evaluation_duration_milliseconds_bucket{policy_name="myPolicyName",le="+Inf"} 1
 			test_prefix_policy_evaluation_duration_milliseconds_sum{policy_name="myPolicyName"} 10
 			test_prefix_policy_evaluation_duration_milliseconds_count{policy_name="myPolicyName"} 1


### PR DESCRIPTION
Testing in a real use case, sometimes specially with the filter policy the evaluation time is over 1s. So I think it's ok to add other higher buckets.