### PR TITLE
fix: sec warning for defer response body close

### DIFF
--- a/openapi/openapi_utils.go
+++ b/openapi/openapi_utils.go
@@ -270,6 +270,9 @@ func deserializeSpec(spec []byte, errorWrapper error) (*OpenAPISpec, error) {
 func fetchOpenAPI(url string) (*OpenAPISpec, error) {
 	resp, err := http.DefaultClient.Get(url)
 	if err != nil {
+		if resp != nil && resp.Body != nil {
+			resp.Body.Close()
+		}
 		return nil, fmt.Errorf("%w: %s", ErrRequestFailed, err)
 	}
 	defer resp.Body.Close()

--- a/openapi/openapi_utils.go
+++ b/openapi/openapi_utils.go
@@ -270,12 +270,9 @@ func deserializeSpec(spec []byte, errorWrapper error) (*OpenAPISpec, error) {
 func fetchOpenAPI(url string) (*OpenAPISpec, error) {
 	resp, err := http.DefaultClient.Get(url)
 	if err != nil {
-		if resp != nil && resp.Body != nil {
-			resp.Body.Close()
-		}
 		return nil, fmt.Errorf("%w: %s", ErrRequestFailed, err)
 	}
-	defer resp.Body.Close()
+	defer func() { resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("%w: invalid status code %d", ErrRequestFailed, resp.StatusCode)

--- a/openapi/openapi_utils_test.go
+++ b/openapi/openapi_utils_test.go
@@ -26,8 +26,10 @@ import (
 	"gopkg.in/h2non/gock.v1"
 )
 
-func TestFetchOpenAPI(t *testing.T) {
+func TestfetchOpenAPI(log, t *testing.T) {
 	t.Run("fetches json OAS", func(t *testing.T) {
+		log, _ := test.NewNullLogger()
+
 		defer gock.Off()
 
 		gock.New("http://localhost:3000").
@@ -37,7 +39,7 @@ func TestFetchOpenAPI(t *testing.T) {
 
 		url := "http://localhost:3000/documentation/json"
 
-		openApiSpec, err := fetchOpenAPI(url)
+		openApiSpec, err := fetchOpenAPI(log, url)
 
 		require.True(t, gock.IsDone(), "Mock has not been invoked")
 		require.NoError(t, err, "unexpected error")
@@ -84,7 +86,7 @@ func TestFetchOpenAPI(t *testing.T) {
 	t.Run("request execution fails for invalid URL", func(t *testing.T) {
 		url := "http://invalidUrl.com"
 
-		_, err := fetchOpenAPI(url)
+		_, err := fetchOpenAPI(log, url)
 
 		t.Logf("Expected error occurred: %s", err.Error())
 		require.True(t, errors.Is(err, ErrRequestFailed), "unexpected error")
@@ -93,7 +95,7 @@ func TestFetchOpenAPI(t *testing.T) {
 	t.Run("request execution fails for invalid URL syntax", func(t *testing.T) {
 		url := "	http://url with a tab.com"
 
-		_, err := fetchOpenAPI(url)
+		_, err := fetchOpenAPI(log, url)
 
 		t.Logf("Expected error occurred: %s", err.Error())
 		require.True(t, errors.Is(err, ErrRequestFailed), "unexpected error")
@@ -109,7 +111,7 @@ func TestFetchOpenAPI(t *testing.T) {
 
 		url := "http://localhost:3000/documentation/json"
 
-		_, err := fetchOpenAPI(url)
+		_, err := fetchOpenAPI(log, url)
 
 		t.Logf("Expected error occurred: %s", err.Error())
 		require.True(t, errors.Is(err, ErrRequestFailed), "unexpected error")
@@ -124,7 +126,7 @@ func TestFetchOpenAPI(t *testing.T) {
 
 		url := "http://localhost:3000/documentation/json"
 
-		_, err := fetchOpenAPI(url)
+		_, err := fetchOpenAPI(log, url)
 
 		t.Logf("Expected error occurred: %s", err.Error())
 		require.True(t, errors.Is(err, ErrRequestFailed), "unexpected error")

--- a/openapi/openapi_utils_test.go
+++ b/openapi/openapi_utils_test.go
@@ -26,10 +26,10 @@ import (
 	"gopkg.in/h2non/gock.v1"
 )
 
-func TestfetchOpenAPI(log, t *testing.T) {
-	t.Run("fetches json OAS", func(t *testing.T) {
-		log, _ := test.NewNullLogger()
+func TestFetchOpenAPI(t *testing.T) {
+	log, _ := test.NewNullLogger()
 
+	t.Run("fetches json OAS", func(t *testing.T) {
 		defer gock.Off()
 
 		gock.New("http://localhost:3000").


### PR DESCRIPTION
This fixes

```
[/github/workspace/openapi/openapi_utils.go:275] - G307 (CWE-703): Deferring unsafe method "Close" on type "io.ReadCloser" (Confidence: HIGH, Severity: MEDIUM)
    274: 	}
  > 275: 	defer resp.Body.Close()
    276: 
```

Example job: https://github.com/rond-authz/rond/actions/runs/4144009188/jobs/7166550436#step:4:72