### PR TITLE
fix: add permissions field to binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+
+- correctly manage binding permissions in grant api
+
 ## 1.5.0 - 19-10-2022
 
 ## 1.4.3 - 12-10-2022

--- a/service/standalone_apis.go
+++ b/service/standalone_apis.go
@@ -194,10 +194,11 @@ func grantHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	bindingToCreate := types.Binding{
-		BindingID: uuid.New().String(),
-		Groups:    reqBody.Groups,
-		Roles:     reqBody.Roles,
-		Subjects:  reqBody.Subjects,
+		BindingID:   uuid.New().String(),
+		Groups:      reqBody.Groups,
+		Permissions: reqBody.Permissions,
+		Roles:       reqBody.Roles,
+		Subjects:    reqBody.Subjects,
 	}
 
 	if resourceType != "" {

--- a/service/standalone_apis_test.go
+++ b/service/standalone_apis_test.go
@@ -555,10 +555,11 @@ func TestGrantHandler(t *testing.T) {
 		defer gock.Flush()
 
 		reqBody := setupGrantRequestBody(t, GrantRequestBody{
-			Subjects:   []string{"piero"},
-			ResourceID: "projectID",
-			Roles:      []string{"editor"},
-			Groups:     []string{"test-group"},
+			Subjects:    []string{"piero"},
+			ResourceID:  "projectID",
+			Roles:       []string{"editor"},
+			Permissions: []string{"test-permission"},
+			Groups:      []string{"test-group"},
 		})
 
 		gock.DisableNetworking()
@@ -569,9 +570,6 @@ func TestGrantHandler(t *testing.T) {
 				bodyBytes, err := io.ReadAll(req.Body)
 				require.Nil(t, err, "unxpected error reading body in matcher")
 
-				containsNull := strings.Contains(string(bodyBytes), `"permissions":null`)
-				require.False(t, containsNull, "unexpected null found")
-
 				err = json.Unmarshal(bodyBytes, &body)
 				require.Nil(t, err, "unxpected error parsing body in matcher")
 
@@ -580,10 +578,11 @@ func TestGrantHandler(t *testing.T) {
 
 				body.BindingID = "REDACTED"
 				require.Equal(t, types.Binding{
-					BindingID: "REDACTED",
-					Groups:    []string{"test-group"},
-					Roles:     []string{"editor"},
-					Subjects:  []string{"piero"},
+					BindingID:   "REDACTED",
+					Groups:      []string{"test-group"},
+					Permissions: []string{"test-permission"},
+					Roles:       []string{"editor"},
+					Subjects:    []string{"piero"},
 					Resource: &types.Resource{
 						ResourceType: "my-resource",
 						ResourceID:   "projectID",


### PR DESCRIPTION
Right now when we create a binding and we pass permissions in the request body, they are ignored when the binding is created