### PR TITLE
fix(#210): allowed value log in response policy evaluation

### DIFF
--- a/core/opaevaluator.go
+++ b/core/opaevaluator.go
@@ -344,44 +344,26 @@ func (evaluator *OPAEvaluator) Evaluate(logger *logrus.Entry) (interface{}, erro
 		"policy_name": evaluator.PolicyName,
 	}).Observe(float64(opaEvaluationTime.Milliseconds()))
 
+	allowed, responseBodyOverwriter := processResults(results)
 	logger.WithFields(logrus.Fields{
 		"evaluationTimeMicroseconds": opaEvaluationTime.Microseconds(),
 		"policyName":                 evaluator.PolicyName,
 		"partialEval":                false,
-		"allowed":                    verifyAllowed(results),
+		"allowed":                    allowed,
 		"resultsLength":              len(results),
 		"matchedPath":                evaluator.routerInfo.MatchedPath,
 		"requestedPath":              evaluator.routerInfo.RequestedPath,
 		"method":                     evaluator.routerInfo.Method,
 	}).Debug("policy evaluation completed")
 
-	// Use strict allowed check for basic request flow allow policies.
-	if results.Allowed() {
-		logger.WithFields(logrus.Fields{
-			"policyName":    evaluator.PolicyName,
-			"allowed":       results.Allowed(),
-			"resultsLength": len(results),
-		}).Tracef("policy results")
-		return nil, nil
-	}
-
-	// Here extract first result set to get the response body for the response policy evaluation.
-	// The results returned by OPA are a list of Results object with fields:
-	// - Expressions: list of list
-	// - Bindings: object
-	// e.g. [{Expressions:[[map["element": true]]] Bindings:map[]}]
-	// Since we are ALWAYS querying ONE specific policy the result length could not be greater than 1
-	if len(results) == 1 {
-		if exprs := results[0].Expressions; len(exprs) == 1 {
-			if value, ok := exprs[0].Value.([]interface{}); ok && value != nil && len(value) != 0 {
-				return value[0], nil
-			}
-		}
-	}
-
 	logger.WithFields(logrus.Fields{
 		"policyName": evaluator.PolicyName,
-	}).Error("policy resulted in not allowed")
+		"allowed":    allowed,
+	}).Info("policy result")
+
+	if allowed {
+		return responseBodyOverwriter, nil
+	}
 	return nil, fmt.Errorf("RBAC policy evaluation failed, user is not allowed")
 }
 
@@ -449,31 +431,28 @@ func LoadRegoModule(rootDirectory string) (*OPAModuleConfig, error) {
 	}, nil
 }
 
-// verifyAllowed replicates the ResultSet.Allowed function with some slight differences.
-// Since we allow for non boolean return values we use the type assertion to understand
-// whether the returned value is an actual boolean and use it, otherwise we verify the
-// returned value is at least a set containing something, if that's the case we assume
-// this is a custom payload for a response policy and return true regardless.
-//
-// NOTE: do not rely on this function for decision-making conditions; use it only for
-// debugging and informative logging!
-//
-// cfr: https://pkg.go.dev/github.com/open-policy-agent/opa/rego#ResultSet.Allowed
-func verifyAllowed(rs rego.ResultSet) bool {
-	if len(rs) == 1 && len(rs[0].Bindings) == 0 {
-		if exprs := rs[0].Expressions; len(exprs) == 1 {
-			// Check if there is a single boolean expression.
-			if b, ok := exprs[0].Value.(bool); ok {
-				return b
-			}
+func processResults(results rego.ResultSet) (allowed bool, responseBodyOverwriter any) {
+	// Use strict allowed check for basic request flow allow policies.
+	if results.Allowed() {
+		allowed = true
+		return
+	}
 
-			// Check if there is at least a value in the returned set,
-			// if an empty set is returned the policy must have failed.
-			if expressionList, isExpressionList := exprs[0].Value.([]interface{}); len(expressionList) == 0 || !isExpressionList {
-				return false
+	// Here extract first result set to get the response body for the response policy evaluation.
+	// The results returned by OPA are a list of Results object with fields:
+	// - Expressions: list of list
+	// - Bindings: object
+	// e.g. [{Expressions:[[map["element": true]]] Bindings:map[]}]
+	// Since we are ALWAYS querying ONE specific policy the result length could not be greater than 1
+	if len(results) == 1 {
+		if exprs := results[0].Expressions; len(exprs) == 1 {
+			if value, ok := exprs[0].Value.([]interface{}); ok && value != nil && len(value) != 0 {
+				allowed = true
+				responseBodyOverwriter = value[0]
+				return
 			}
-			return true
 		}
 	}
-	return false
+
+	return
 }

--- a/core/opaevaluator.go
+++ b/core/opaevaluator.go
@@ -348,7 +348,7 @@ func (evaluator *OPAEvaluator) Evaluate(logger *logrus.Entry) (interface{}, erro
 		"evaluationTimeMicroseconds": opaEvaluationTime.Microseconds(),
 		"policyName":                 evaluator.PolicyName,
 		"partialEval":                false,
-		"allowed":                    results.Allowed(),
+		"allowed":                    len(results) == 1 && len(results[0].Expressions) == 1,
 		"resultsLength":              len(results),
 		"matchedPath":                evaluator.routerInfo.MatchedPath,
 		"requestedPath":              evaluator.routerInfo.RequestedPath,

--- a/core/opaevaluator.go
+++ b/core/opaevaluator.go
@@ -344,14 +344,11 @@ func (evaluator *OPAEvaluator) Evaluate(logger *logrus.Entry) (interface{}, erro
 		"policy_name": evaluator.PolicyName,
 	}).Observe(float64(opaEvaluationTime.Milliseconds()))
 
-	laxAllowed := verifyAllowed(results)
-	fmt.Printf("AAAAA %t %t %+v\n\n", laxAllowed, results.Allowed(), results)
-
 	logger.WithFields(logrus.Fields{
 		"evaluationTimeMicroseconds": opaEvaluationTime.Microseconds(),
 		"policyName":                 evaluator.PolicyName,
 		"partialEval":                false,
-		"allowed":                    laxAllowed,
+		"allowed":                    verifyAllowed(results),
 		"resultsLength":              len(results),
 		"matchedPath":                evaluator.routerInfo.MatchedPath,
 		"requestedPath":              evaluator.routerInfo.RequestedPath,

--- a/core/opaevaluator.go
+++ b/core/opaevaluator.go
@@ -449,10 +449,15 @@ func LoadRegoModule(rootDirectory string) (*OPAModuleConfig, error) {
 	}, nil
 }
 
-// verifyAllowed replicates the ResultSet.Allowed function with a sligth difference
-// since we allow for non boolean return values we use the type assertion to understand
-// whether the returned value is an actual boolean and use it, otherwise we assume this
-// is a custom payload for a response policy and return true regardless.
+// verifyAllowed replicates the ResultSet.Allowed function with some slight differences.
+// Since we allow for non boolean return values we use the type assertion to understand
+// whether the returned value is an actual boolean and use it, otherwise we verify the
+// returned value is at least a set containing something, if that's the case we assume
+// this is a custom payload for a response policy and return true regardless.
+//
+// NOTE: do not rely on this function for decision-making conditions; use it only for
+// debugging and informative logging!
+//
 // cfr: https://pkg.go.dev/github.com/open-policy-agent/opa/rego#ResultSet.Allowed
 func verifyAllowed(rs rego.ResultSet) bool {
 	if len(rs) == 1 && len(rs[0].Bindings) == 0 {

--- a/core/sdk_test.go
+++ b/core/sdk_test.go
@@ -609,7 +609,7 @@ func TestEvaluateResponsePolicy(t *testing.T) {
 					require.NotNil(t, actual)
 					delete(actual.Data, "evaluationTimeMicroseconds")
 					require.Equal(t, logrus.Fields{
-						"allowed":       false,
+						"allowed":       true,
 						"requestedPath": testCase.path,
 						"matchedPath":   evaluatorInfo.evaluatorOptions.RouterInfo.MatchedPath,
 						"method":        testCase.method,

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/mia-platform/glogger/v2 v2.1.3
 	github.com/open-policy-agent/opa v0.53.1
 	github.com/prometheus/client_golang v1.16.0
+	github.com/prometheus/common v0.42.0
 	github.com/samber/lo v1.38.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.8.4
@@ -57,7 +58,6 @@ require (
 	github.com/perimeterx/marshmallow v1.1.4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
-	github.com/prometheus/common v0.42.0 // indirect
 	github.com/prometheus/procfs v0.10.1 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
 	github.com/spf13/afero v1.9.2 // indirect


### PR DESCRIPTION
[Allowed](https://pkg.go.dev/github.com/open-policy-agent/opa@v0.53.1/rego#ResultSet.Allowed) documentation states:

>Allowed is a helper method that'll return true if all of these conditions hold: - the result set only has one element - there is only one expression in the result set's only element - that expression has the value `true` - there are no bindings.
>
>If bindings are present, this will yield `false`: it would be a pitfall to return `true` for a query like `data.authz.allow = x`, which always has result set element with value true, but could also have a binding `x: false`. 

Since the policy is actually returning the new body it is expected to return a single expression with value different from `true`

To verify:

 - [x] policy failure logs false
 - [x] differentiate somehow between Evaluation for response and evaluation for request; maybe replicate the Allowed function but with a type assertion on boolean expression


Note:

The `verifyAllowed` function is supposed to be an internal utility only for logging purposes; I would not use it to decide what to return since it is too lax, I'd still rely on the `results.Allowed` func for that until a better solution is found.