### PR TITLE
feat(#207): add user id to input struct

### DIFF
--- a/core/input.go
+++ b/core/input.go
@@ -46,6 +46,7 @@ type InputResponse struct {
 }
 
 type InputUser struct {
+	ID                     string                   `json:"id,omitempty"`
 	Properties             map[string]interface{}   `json:"properties,omitempty"`
 	Groups                 []string                 `json:"groups,omitempty"`
 	Bindings               []types.Binding          `json:"bindings,omitempty"`

--- a/main_test.go
+++ b/main_test.go
@@ -273,7 +273,7 @@ func TestEntrypoint(t *testing.T) {
 			if r.URL.Path == "/documentation/json" {
 				return false
 			}
-			if r.URL.Path == "/users/" && r.URL.Host == "localhost:3001" {
+			if (r.URL.Path == "/users/" || r.URL.Path == "/assert-user") && r.URL.Host == "localhost:3001" {
 				return false
 			}
 			return true

--- a/main_test.go
+++ b/main_test.go
@@ -312,6 +312,23 @@ func TestEntrypoint(t *testing.T) {
 			require.True(t, gock.IsDone(), "the proxy blocks the request when the permissions are granted.")
 		})
 
+		t.Run("ok - user assertions", func(t *testing.T) {
+			gock.Flush()
+			gock.New("http://localhost:3001/").
+				Get("/assert-user").
+				Reply(200)
+
+			req, err := http.NewRequest(http.MethodGet, "http://localhost:3000/assert-user", nil)
+			require.Nil(t, err)
+
+			req.Header.Set("miauserid", "the-user-id")
+			resp, err := http.DefaultClient.Do(req)
+
+			require.Equal(t, nil, err)
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+			require.True(t, gock.IsDone(), "the proxy blocks the request when the permissions are granted.")
+		})
+
 		t.Run("forbidden - opa evaluation fail", func(t *testing.T) {
 			gock.Flush()
 			gock.New("http://localhost:3001/").

--- a/main_test.go
+++ b/main_test.go
@@ -314,18 +314,19 @@ func TestEntrypoint(t *testing.T) {
 
 		t.Run("ok - user assertions", func(t *testing.T) {
 			gock.Flush()
+
 			gock.New("http://localhost:3001/").
 				Get("/assert-user").
 				Reply(200)
 
 			req, err := http.NewRequest(http.MethodGet, "http://localhost:3000/assert-user", nil)
 			require.Nil(t, err)
-
 			req.Header.Set("miauserid", "the-user-id")
-			resp, err := http.DefaultClient.Do(req)
 
+			resp, err := http.DefaultClient.Do(req)
 			require.Equal(t, nil, err)
 			require.Equal(t, http.StatusOK, resp.StatusCode)
+
 			require.True(t, gock.IsDone(), "the proxy blocks the request when the permissions are granted.")
 		})
 
@@ -1300,7 +1301,7 @@ func TestEntrypoint(t *testing.T) {
 			File("./mocks/pathsWithWildCardCollision2.json")
 
 		setEnvs(t, []env{
-			{name: "HTTP_PORT", value: "3039"},
+			{name: "HTTP_PORT", value: "3060"},
 			{name: "TARGET_SERVICE_HOST", value: "localhost:3038"},
 			{name: "TARGET_SERVICE_OAS_PATH", value: "/documentation/json"},
 			{name: "OPA_MODULES_DIRECTORY", value: "./mocks/rego-policies"},
@@ -1350,7 +1351,7 @@ func TestEntrypoint(t *testing.T) {
 		gock.New("http://localhost:3038/foo/count").
 			Get("/foo/count").
 			Reply(200)
-		req, err := http.NewRequest("GET", "http://localhost:3039/foo/count", nil)
+		req, err := http.NewRequest("GET", "http://localhost:3060/foo/count", nil)
 		require.NoError(t, err)
 
 		req.Header.Set("miausergroups", "group1")
@@ -1384,7 +1385,7 @@ func TestEntrypoint(t *testing.T) {
 			File("./mocks/pathsWithWildCardCollision.json")
 
 		setEnvs(t, []env{
-			{name: "HTTP_PORT", value: "3039"},
+			{name: "HTTP_PORT", value: "3070"},
 			{name: "TARGET_SERVICE_HOST", value: "localhost:3038"},
 			{name: "TARGET_SERVICE_OAS_PATH", value: "/documentation/json"},
 			{name: "OPA_MODULES_DIRECTORY", value: "./mocks/rego-policies"},
@@ -1434,7 +1435,7 @@ func TestEntrypoint(t *testing.T) {
 		gock.New("http://localhost:3038/foo/count").
 			Patch("/foo/count").
 			Reply(200)
-		req, err := http.NewRequest("PATCH", "http://localhost:3039/foo/count", nil)
+		req, err := http.NewRequest("PATCH", "http://localhost:3070/foo/count", nil)
 		require.NoError(t, err)
 
 		req.Header.Set("miausergroups", "group1")

--- a/mocks/rego-policies/example.rego
+++ b/mocks/rego-policies/example.rego
@@ -83,6 +83,10 @@ testingPathParamsAbsence {
 }
 
 allow_view {
-    id :=  object.get(input,["request","pathParams", "id"], false)
+    id := object.get(input,["request","pathParams", "id"], false)
     id
+}
+
+assert_user {
+	input.user.id == "the-user-id"
 }

--- a/mocks/rego-policies/example.rego
+++ b/mocks/rego-policies/example.rego
@@ -60,7 +60,6 @@ ft_checker {
 	true
 }
 
-
 response_policy1 {
 	true
 }

--- a/mocks/rego-policies/example.rego
+++ b/mocks/rego-policies/example.rego
@@ -83,8 +83,8 @@ testingPathParamsAbsence {
 }
 
 allow_view {
-    id := object.get(input,["request","pathParams", "id"], false)
-    id
+	id := object.get(input,["request","pathParams", "id"], false)
+	id
 }
 
 assert_user {

--- a/mocks/simplifiedMock.json
+++ b/mocks/simplifiedMock.json
@@ -6,6 +6,13 @@
     "version": "3.2.3"
   },
   "paths": {
+    "/assert-user": {
+      "get": {
+        "x-permission": {
+          "allow": "assert_user"
+        }
+      }
+    },
     "/users/": {
       "head": {
         "x-permission": {

--- a/openapi/evaluators_test.go
+++ b/openapi/evaluators_test.go
@@ -41,7 +41,7 @@ func TestCreatePolicyEvaluators(t *testing.T) {
 
 		policyEvals, err := SetupEvaluators(ctx, logger, openApiSpec, opaModuleConfig, nil)
 		require.NoError(t, err, "unexpected error creating evaluators")
-		require.Len(t, policyEvals, 4, "unexpected length")
+		require.Len(t, policyEvals, 5, "unexpected length")
 	})
 
 	t.Run("with complete oas mock", func(t *testing.T) {

--- a/openapi/openapi_utils_test.go
+++ b/openapi/openapi_utils_test.go
@@ -46,6 +46,13 @@ func TestFetchOpenAPI(t *testing.T) {
 		require.NoError(t, err, "unexpected error")
 		require.NotNil(t, openApiSpec, "unexpected nil result")
 		require.Equal(t, OpenAPIPaths{
+			"/assert-user": PathVerbs{
+				"get": VerbConfig{
+					PermissionV2: &core.RondConfig{
+						RequestFlow: core.RequestFlow{PolicyName: "assert_user"},
+					},
+				},
+			},
 			"/users/": PathVerbs{
 				"get": VerbConfig{
 					PermissionV2: &core.RondConfig{
@@ -226,6 +233,13 @@ func TestLoadOAS(t *testing.T) {
 		require.NoError(t, err, "unexpected error")
 		require.NotNil(t, openApiSpec, "unexpected nil result")
 		require.Equal(t, OpenAPIPaths{
+			"/assert-user": PathVerbs{
+				"get": VerbConfig{
+					PermissionV2: &core.RondConfig{
+						RequestFlow: core.RequestFlow{PolicyName: "assert_user"},
+					},
+				},
+			},
 			"/users/": PathVerbs{
 				"get": VerbConfig{
 					PermissionV2: &core.RondConfig{

--- a/sdk/evaluator_test.go
+++ b/sdk/evaluator_test.go
@@ -150,6 +150,7 @@ func TestEvaluateRequestPolicy(t *testing.T) {
 				method: http.MethodGet,
 				path:   "/users/",
 				user: types.User{
+					UserID:     "the-user-id",
 					UserGroups: []string{"my-group"},
 					UserRoles: []types.Role{
 						{
@@ -169,6 +170,7 @@ func TestEvaluateRequestPolicy(t *testing.T) {
 				},
 				opaModuleContent: `package policies
 				todo {
+					input.user.id == "the-user-id"
 					input.user.groups[0] == "my-group"
 					input.user.roles[0].roleId == "rid"
 					input.user.bindings[0].resource.resourceType == "my-resource"

--- a/sdk/rondinput/http/input.go
+++ b/sdk/rondinput/http/input.go
@@ -63,6 +63,7 @@ func (req requestInfo) Input(user types.User, responseBody any) (core.Input, err
 			Body: responseBody,
 		},
 		User: core.InputUser{
+			ID:         user.UserID,
 			Properties: user.Properties,
 			Groups:     user.UserGroups,
 			Bindings:   user.UserBindings,

--- a/sdk/rondinput/http/input_test.go
+++ b/sdk/rondinput/http/input_test.go
@@ -101,4 +101,23 @@ func TestRondInput(t *testing.T) {
 			require.Nil(t, input.Request.Body)
 		})
 	})
+
+	t.Run("request userinfo remapping", func(t *testing.T) {
+		user := types.User{
+			UserID:       "UserID",
+			UserGroups:   []string{"UserGroups"},
+			UserRoles:    []types.Role{},
+			UserBindings: []types.Binding{},
+			Properties:   map[string]any{"key": "val"},
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/", bytes.NewReader([]byte{}))
+
+		rondRequest := NewInput(req, clientTypeHeaderKey, pathParams)
+		input, err := rondRequest.Input(user, nil)
+
+		require.NoError(t, err, "Unexpected error")
+		require.Equal(t, user.UserID, input.User.ID)
+		require.EqualValues(t, user.Properties, input.User.Properties)
+	})
 }

--- a/sdk/sdk_test.go
+++ b/sdk/sdk_test.go
@@ -279,6 +279,7 @@ type FakeInput struct {
 func (i FakeInput) Input(user types.User, responseBody any) (core.Input, error) {
 	return core.Input{
 		User: core.InputUser{
+			ID:         user.UserID,
 			Properties: user.Properties,
 			Groups:     user.UserGroups,
 			Bindings:   user.UserBindings,


### PR DESCRIPTION
This PR aims at closing #207; if this gets merged we could close #208

I've added unit tests on the SDK and input creator but also managed to add a specific integration test case to make sure it will properly be supported with the sidecar