### PR TITLE
ci: new job names

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,12 +6,12 @@ on:
 jobs:
   tests:
     name: Test
-    #run-name: Tests with go version ${{ matrix.go_version }} on OS ${{matrix.os}}
-    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         go_version: ['1.20', latest]
         os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+
     steps:
       - uses: actions/checkout@v3
       - name: Use golang ${{ matrix.go_version }}
@@ -29,9 +29,32 @@ jobs:
         with:
           path-to-profile: coverage.out
 
+  test-latest:
+    name: Test latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use golang ${{ matrix.go_version }}
+        uses: actions/setup-go@v4
+        with:
+          check-latest: true
+      - name: Go version
+        run: go version
+      - name: Go get dependencies
+        run: go get -v -t -d ./...
+      - name: Run tests
+        run: make coverage
+      - name: Send the coverage output
+        uses: shogo82148/actions-goveralls@v1
+        with:
+          path-to-profile: coverage.out
+
   bench:
     name: Benchmark
-    #run-name: Bench with go version ${{ matrix.go_version }} on OS ${{matrix.os}}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   tests:
     name: Test
-    run-name: Tests with go version ${{ matrix.go_version }} on OS ${{matrix.os}}
+    #run-name: Tests with go version ${{ matrix.go_version }} on OS ${{matrix.os}}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -31,7 +31,7 @@ jobs:
 
   bench:
     name: Benchmark
-    run-name: Bench with go version ${{ matrix.go_version }} on OS ${{matrix.os}}
+    #run-name: Bench with go version ${{ matrix.go_version }} on OS ${{matrix.os}}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,8 @@ on:
   push:
 jobs:
   tests:
-    name: Test with go version ${{ matrix.go_version }} on OS ${{matrix.os}}
+    name: Test
+    run-name: Tests with go version ${{ matrix.go_version }} on OS ${{matrix.os}}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -29,7 +30,8 @@ jobs:
           path-to-profile: coverage.out
 
   bench:
-    name: Bench with go version ${{ matrix.go_version }} on OS ${{matrix.os}}
+    name: Benchmark
+    run-name: Bench with go version ${{ matrix.go_version }} on OS ${{matrix.os}}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go_version: [1.19]
+        go_version: ['1.20', latest]
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v3
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go_version: [1.19]
+        go_version: ['1.20']
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        go_version: ['1.20', latest]
+        go_version: ['1.20']
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
I wanted to set requirements for PR to pass tests, however you are required to match the action job name, which previously included the golang version, therefore changing when updating golang.

With this PR I want to stabilize job names to be always consistent.

<img width="879" alt="Screenshot 2023-08-01 alle 09 48 40" src="https://github.com/rond-authz/rond/assets/7142570/6d494d86-13ce-4963-bbde-053adfb1714a">
