### PR TITLE
feat: improve sdk request evaluator interface

### DIFF
--- a/core/errors.go
+++ b/core/errors.go
@@ -27,6 +27,7 @@ var (
 	ErrPolicyEvalFailed         = fmt.Errorf("policy evaluation failed")
 	ErrPartialPolicyEvalFailed  = fmt.Errorf("partial %w", ErrPolicyEvalFailed)
 	ErrResponsePolicyEvalFailed = fmt.Errorf("response %w", ErrPolicyEvalFailed)
+	ErrPolicyNotAllowed         = fmt.Errorf("policy not allowed")
 
 	ErrFailedInputParse                  = fmt.Errorf("failed input parse")
 	ErrFailedInputEncode                 = fmt.Errorf("failed input encode")

--- a/core/opaevaluator.go
+++ b/core/opaevaluator.go
@@ -211,7 +211,7 @@ func (evaluator *OPAEvaluator) Evaluate(logger logging.Logger, options *PolicyEv
 	if allowed {
 		return responseBodyOverwriter, nil
 	}
-	return nil, ErrPolicyEvalFailed
+	return nil, ErrPolicyNotAllowed
 }
 
 func (evaluator *OPAEvaluator) getContext() context.Context {

--- a/core/partialevaluators_test.go
+++ b/core/partialevaluators_test.go
@@ -108,7 +108,7 @@ func TestPartialResultEvaluators(t *testing.T) {
 			evaluator, err := partialEvaluators.GetEvaluatorFromPolicy(ctx, "column_policy", input, nil)
 			require.NoError(t, err)
 			_, err = evaluator.Evaluate(logger, nil)
-			require.EqualError(t, err, ErrPolicyEvalFailed.Error())
+			require.EqualError(t, err, ErrPolicyNotAllowed.Error())
 		})
 	})
 
@@ -357,7 +357,7 @@ func TestPartialResultEvaluators(t *testing.T) {
 			evaluator, err := partialEvaluators.GetEvaluatorFromPolicy(context.Background(), "deny", input, nil)
 			require.NoError(t, err)
 			_, _, err = evaluator.PolicyEvaluation(logger, nil)
-			require.EqualError(t, err, ErrPolicyEvalFailed.Error())
+			require.EqualError(t, err, ErrPolicyNotAllowed.Error())
 		})
 	})
 }

--- a/internal/fake/sdk.go
+++ b/internal/fake/sdk.go
@@ -22,7 +22,8 @@ import (
 )
 
 type RequestPolicyEvaluatorResult struct {
-	Err error
+	Err          error
+	PolicyResult sdk.PolicyResult
 }
 
 type SDKEvaluator struct {
@@ -49,7 +50,7 @@ func (s SDKEvaluator) EvaluateRequestPolicy(ctx context.Context, input core.Inpu
 	if s.requestPolicyEvaluatorResult == nil {
 		return sdk.PolicyResult{}, nil
 	}
-	return sdk.PolicyResult{}, s.requestPolicyEvaluatorResult.Err
+	return s.requestPolicyEvaluatorResult.PolicyResult, s.requestPolicyEvaluatorResult.Err
 }
 
 func (e SDKEvaluator) EvaluateResponsePolicy(ctx context.Context, input core.Input, options *sdk.EvaluateOptions) ([]byte, error) {

--- a/sdk/evaluator.go
+++ b/sdk/evaluator.go
@@ -17,6 +17,7 @@ package sdk
 import (
 	"context"
 	"encoding/json"
+	"errors"
 
 	"github.com/rond-authz/rond/core"
 	"github.com/rond-authz/rond/logging"
@@ -76,7 +77,7 @@ func (e evaluator) EvaluateRequestPolicy(ctx context.Context, rondInput core.Inp
 		EnableResourcePermissionsMapOptimization: rondConfig.Options.EnableResourcePermissionsMapOptimization,
 	})
 	if err != nil {
-		return PolicyResult{}, nil
+		return PolicyResult{}, err
 	}
 
 	opaEvaluatorOptions := e.evaluatorOptions.opaEvaluatorOptions(logger)
@@ -104,6 +105,9 @@ func (e evaluator) EvaluateRequestPolicy(ctx context.Context, rondInput core.Inp
 			"policyName": rondConfig.RequestFlow.PolicyName,
 			"message":    err.Error(),
 		}).Error("RBAC policy evaluation failed")
+		if errors.Is(err, core.ErrPolicyNotAllowed) {
+			return PolicyResult{}, nil
+		}
 		return PolicyResult{}, err
 	}
 

--- a/sdk/evaluator_test.go
+++ b/sdk/evaluator_test.go
@@ -79,7 +79,6 @@ func TestEvaluateRequestPolicy(t *testing.T) {
 				},
 
 				expectedPolicy: PolicyResult{},
-				expectedErr:    core.ErrPolicyEvalFailed,
 			},
 			"not allowed policy result": {
 				method: http.MethodGet,
@@ -90,7 +89,6 @@ func TestEvaluateRequestPolicy(t *testing.T) {
 				opaModuleContent: `package policies todo { false }`,
 
 				expectedPolicy: PolicyResult{},
-				expectedErr:    core.ErrPolicyEvalFailed,
 			},
 			"with empty filter query": {
 				method:      http.MethodGet,
@@ -473,7 +471,7 @@ func TestEvaluateResponsePolicy(t *testing.T) {
 					false
 					body := input.response.body
 				}`,
-				expectedErr:  core.ErrPolicyEvalFailed,
+				expectedErr:  core.ErrPolicyNotAllowed,
 				expectedBody: "",
 				notAllowed:   true,
 			},

--- a/service/handler.go
+++ b/service/handler.go
@@ -138,6 +138,11 @@ func EvaluateRequest(
 		utils.FailResponseWithCode(w, http.StatusForbidden, "RBAC policy evaluation failed", utils.NO_PERMISSIONS_ERROR_MESSAGE)
 		return err
 	}
+	if !result.Allowed {
+		logger.Error("RBAC policy evaluation failed")
+		utils.FailResponseWithCode(w, http.StatusForbidden, "RBAC policy evaluation failed", utils.NO_PERMISSIONS_ERROR_MESSAGE)
+		return fmt.Errorf("RBAC policy evaluation failed")
+	}
 
 	queryHeaderKey := BASE_ROW_FILTER_HEADER_KEY
 	if permission.RequestFlow.QueryOptions.HeaderName != "" {

--- a/service/router_test.go
+++ b/service/router_test.go
@@ -361,7 +361,7 @@ func TestSetupRoutesIntegration(t *testing.T) {
 		require.Equal(t, http.StatusOK, w.Result().StatusCode)
 	})
 
-	t.Run("invokes unknown API", func(t *testing.T) {
+	t.Run("invokes unknown API - with mocked true evaluator", func(t *testing.T) {
 		var invoked bool
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			invoked = true
@@ -377,7 +377,11 @@ func TestSetupRoutesIntegration(t *testing.T) {
 
 		eval, err := openapi.SetupEvaluators(ctx, logger, oas, mockOPAModule, nil)
 		require.NoError(t, err)
-		evaluator := fake.NewSDKEvaluator(eval, mockXPermission, nil)
+		evaluator := fake.NewSDKEvaluator(eval, mockXPermission, &fake.RequestPolicyEvaluatorResult{
+			PolicyResult: sdk.PolicyResult{
+				Allowed: true,
+			},
+		})
 
 		ctx := createContext(t,
 			context.Background(),


### PR DESCRIPTION
Maybe, we could also returns the specific not allowed error. What do you think of this change?