### PR TITLE
feat(#268): decouple status routes provisioning from policy setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ mongo-start:
 
 .PHONY: test
 test: clean mongo-start
-	go test ./... -cover -count=1 -race
+	go test ./... -cover -race
 	$(MAKE) clean
 
 .PHONY: coverage

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ mongo-start:
 
 .PHONY: test
 test: clean mongo-start
-	go test ./... -cover -count=1 -race
+	go test ./... -cover -count=1
 	$(MAKE) clean
 
 .PHONY: coverage

--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,12 @@ mongo-start:
 
 .PHONY: test
 test: clean mongo-start
-	go test ./... -cover -count=1
+	go test ./... -cover -count=1 -race
 	$(MAKE) clean
 
 .PHONY: coverage
 coverage: clean mongo-start
-	go test ./... -coverprofile coverage.out -count=1
+	go test ./... -coverprofile coverage.out -count=1 -race=1
 	$(MAKE) clean
 
 .PHONY: bench

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ mongo-start:
 
 .PHONY: test
 test: clean mongo-start
-	go test ./... -cover -count=1
+	go test ./... -cover -count=1 -race
 	$(MAKE) clean
 
 .PHONY: coverage

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ test: clean mongo-start
 
 .PHONY: coverage
 coverage: clean mongo-start
-	go test ./... -coverprofile coverage.out
+	go test ./... -coverprofile -count=1 -race coverage.out
 	$(MAKE) clean
 
 .PHONY: bench

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ test: clean mongo-start
 
 .PHONY: coverage
 coverage: clean mongo-start
-	go test ./... -coverprofile -count=1 coverage.out
+	go test ./... -coverprofile coverage.out -count=1
 	$(MAKE) clean
 
 .PHONY: bench

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ test: clean mongo-start
 
 .PHONY: coverage
 coverage: clean mongo-start
-	go test ./... -coverprofile -count=1 -race coverage.out
+	go test ./... -coverprofile -count=1 coverage.out
 	$(MAKE) clean
 
 .PHONY: bench

--- a/internal/fake/evaluatorFinder.go
+++ b/internal/fake/evaluatorFinder.go
@@ -12,27 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package service
+package fake
 
-import (
-	"testing"
+import "github.com/rond-authz/rond/sdk"
 
-	"github.com/rond-authz/rond/internal/fake"
-	"github.com/stretchr/testify/require"
-)
+type SDKEvaluatorFinder struct {
+}
 
-func TestSDKBootState(t *testing.T) {
-	sdkBootState := NewSDKBootState()
-
-	t.Run("flow with routine", func(t *testing.T) {
-		completed := make(chan bool, 1)
-		go func() {
-			sdkBootState.Ready(fake.SDKEvaluatorFinder{})
-			completed <- true
-		}()
-
-		sdk := sdkBootState.Get()
-		require.NotNil(t, sdk)
-		require.True(t, <-completed)
-	})
+func (s SDKEvaluatorFinder) FindEvaluator(method, path string) (sdk.Evaluator, error) {
+	return SDKEvaluator{}, nil
 }

--- a/main.go
+++ b/main.go
@@ -138,7 +138,7 @@ func entrypoint(shutdown chan os.Signal) {
 
 	// Routing
 	log.Trace("router setup initialization")
-	router, errChan := service.SetupRouter(log, env, opaModuleConfig, oas, sdkBoot, mongoClient, registry)
+	router, completionChan := service.SetupRouter(log, env, opaModuleConfig, oas, sdkBoot, mongoClient, registry)
 	log.Trace("router setup initialization done")
 
 	srv := &http.Server{
@@ -154,7 +154,7 @@ func entrypoint(shutdown chan os.Signal) {
 	}()
 
 	log.Trace("waiting for router setup initialization to be completed")
-	setupError := <-errChan
+	setupError := <-completionChan
 	log.Trace("router setup initialization completed")
 	if setupError != nil {
 		log.WithField("error", logrus.Fields{"message": err.Error()}).Error("router setup initialization has failed")

--- a/main.go
+++ b/main.go
@@ -180,9 +180,7 @@ func prepSDKOrDie(
 	if err != nil {
 		log.WithFields(logrus.Fields{
 			"error": logrus.Fields{"message": err.Error()},
-		}).Errorf("failed to create sdk")
-		// FIXME: better exit strategy?
-		os.Exit(1)
+		}).Fatalf("failed to create sdk")
 	}
 	return sdk
 }

--- a/main.go
+++ b/main.go
@@ -138,7 +138,7 @@ func entrypoint(shutdown chan os.Signal) {
 
 	// Routing
 	log.Trace("router setup initialization")
-	router, completionChan := service.SetupRouter(log, env, opaModuleConfig, oas, sdkBoot, mongoClient, registry)
+	router, _ := service.SetupRouter(log, env, opaModuleConfig, oas, sdkBoot, mongoClient, registry)
 	log.Trace("router setup initialization done")
 
 	srv := &http.Server{
@@ -153,19 +153,19 @@ func entrypoint(shutdown chan os.Signal) {
 		}
 	}()
 
-	log.Trace("waiting for router setup initialization to be completed")
-	setupError := <-completionChan
-	log.Trace("router setup initialization completed")
-	if setupError != nil {
-		log.WithField("error", logrus.Fields{"message": err.Error()}).Error("router setup initialization has failed")
-		if err := srv.Close(); err != nil {
-			log.
-				WithField("error", logrus.Fields{"messaage": err.Error()}).
-				Fatal("Server close failed")
-		}
-		log.Trace("Server closed")
-		return
-	}
+	// log.Trace("waiting for router setup initialization to be completed")
+	// setupError := <-completionChan
+	// log.Trace("router setup initialization completed")
+	// if setupError != nil {
+	// 	log.WithField("error", logrus.Fields{"message": err.Error()}).Error("router setup initialization has failed")
+	// 	if err := srv.Close(); err != nil {
+	// 		log.
+	// 			WithField("error", logrus.Fields{"messaage": err.Error()}).
+	// 			Fatal("Server close failed")
+	// 	}
+	// 	log.Trace("Server closed")
+	// 	return
+	// }
 
 	// sigterm signal sent from kubernetes
 	signal.Notify(shutdown, syscall.SIGTERM)

--- a/main.go
+++ b/main.go
@@ -153,20 +153,6 @@ func entrypoint(shutdown chan os.Signal) {
 		}
 	}()
 
-	// log.Trace("waiting for router setup initialization to be completed")
-	// setupError := <-completionChan
-	// log.Trace("router setup initialization completed")
-	// if setupError != nil {
-	// 	log.WithField("error", logrus.Fields{"message": err.Error()}).Error("router setup initialization has failed")
-	// 	if err := srv.Close(); err != nil {
-	// 		log.
-	// 			WithField("error", logrus.Fields{"messaage": err.Error()}).
-	// 			Fatal("Server close failed")
-	// 	}
-	// 	log.Trace("Server closed")
-	// 	return
-	// }
-
 	// sigterm signal sent from kubernetes
 	signal.Notify(shutdown, syscall.SIGTERM)
 	// We'll accept graceful shutdowns when quit via  and SIGTERM (Ctrl+/)

--- a/main.go
+++ b/main.go
@@ -131,10 +131,10 @@ func entrypoint(shutdown chan os.Signal) {
 	}
 
 	sdkBoot := service.NewSDKBootState()
-	go func() {
+	go func(sdkBoot *service.SDKBootState) {
 		sdk := prepSDKOrDie(log, env, opaModuleConfig, oas, mongoClientForBuiltin, rondLogger, m)
 		sdkBoot.Ready(sdk)
-	}()
+	}(sdkBoot)
 
 	// Routing
 	log.Trace("router setup initialization")

--- a/main_test.go
+++ b/main_test.go
@@ -1820,7 +1820,6 @@ filter_policy {
 	sdkState := service.NewSDKBootState()
 	sdkState.Ready(rondSDK)
 	router, err := service.SetupRouter(log, env, opa, oas, sdkState, nil, nil)
-	// err = <-completionChan
 	require.NoError(t, err, "unexpected error")
 
 	t.Run("some eval API", func(t *testing.T) {
@@ -1985,7 +1984,6 @@ filter_policy {
 	sdkState := service.NewSDKBootState()
 	sdkState.Ready(rondSDK)
 	router, err := service.SetupRouter(log, env, opa, oas, sdkState, nil, registry)
-	// err = <-completionChan
 	require.NoError(t, err, "unexpected error")
 
 	t.Run("metrics API exposed correctly", func(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -1817,7 +1817,8 @@ filter_policy {
 	})
 	require.NoError(t, err, "unexpected error")
 
-	router, err := service.SetupRouter(log, env, opa, oas, sdk, nil, nil)
+	router, completionChan := service.SetupRouter(log, env, opa, oas, sdk, nil, nil)
+	err = <-completionChan
 	require.NoError(t, err, "unexpected error")
 
 	t.Run("some eval API", func(t *testing.T) {
@@ -1980,7 +1981,8 @@ filter_policy {
 		"policy_name": "myPolicy",
 	}).Observe(123)
 
-	router, err := service.SetupRouter(log, env, opa, oas, sdk, nil, registry)
+	router, completionChan := service.SetupRouter(log, env, opa, oas, sdk, nil, registry)
+	err = <-completionChan
 	require.NoError(t, err, "unexpected error")
 
 	t.Run("metrics API exposed correctly", func(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -1819,8 +1819,8 @@ filter_policy {
 
 	sdkState := service.NewSDKBootState()
 	sdkState.Ready(rondSDK)
-	router, completionChan := service.SetupRouter(log, env, opa, oas, sdkState, nil, nil)
-	err = <-completionChan
+	router, err := service.SetupRouter(log, env, opa, oas, sdkState, nil, nil)
+	// err = <-completionChan
 	require.NoError(t, err, "unexpected error")
 
 	t.Run("some eval API", func(t *testing.T) {
@@ -1984,8 +1984,8 @@ filter_policy {
 	}).Observe(123)
 	sdkState := service.NewSDKBootState()
 	sdkState.Ready(rondSDK)
-	router, completionChan := service.SetupRouter(log, env, opa, oas, sdkState, nil, registry)
-	err = <-completionChan
+	router, err := service.SetupRouter(log, env, opa, oas, sdkState, nil, registry)
+	// err = <-completionChan
 	require.NoError(t, err, "unexpected error")
 
 	t.Run("metrics API exposed correctly", func(t *testing.T) {

--- a/service/opamiddleware.go
+++ b/service/opamiddleware.go
@@ -29,6 +29,11 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+var (
+	ErrSDKNotReadyMessage         = "service not ready to work yet"
+	ErrSDKNotReadyBusinessMessage = "the service is not ready to work yet, try again in a few moments"
+)
+
 type OPAMiddlewareOptions struct {
 	IsStandalone         bool
 	PathPrefixStandalone string
@@ -50,8 +55,7 @@ func OPAMiddleware(
 
 			rondSDK := sdkState.Get()
 			if rondSDK == nil {
-				// TODO: error messages
-				utils.FailResponseWithCode(w, http.StatusServiceUnavailable, "asd", "dsa")
+				utils.FailResponseWithCode(w, http.StatusServiceUnavailable, ErrSDKNotReadyMessage, ErrSDKNotReadyBusinessMessage)
 				return
 			}
 

--- a/service/opamiddleware.go
+++ b/service/opamiddleware.go
@@ -50,6 +50,7 @@ func OPAMiddleware(
 
 			rondSDK := sdkState.Get()
 			if rondSDK == nil {
+				// TODO: error messages
 				utils.FailResponseWithCode(w, http.StatusServiceUnavailable, "asd", "dsa")
 				return
 			}

--- a/service/opamiddleware.go
+++ b/service/opamiddleware.go
@@ -36,7 +36,7 @@ type OPAMiddlewareOptions struct {
 
 func OPAMiddleware(
 	opaModuleConfig *core.OPAModuleConfig,
-	rondSDK sdk.OASEvaluatorFinder,
+	sdkState *SDKBootState,
 	routesToNotProxy []string,
 	targetServiceOASPath string,
 	options *OPAMiddlewareOptions,
@@ -45,6 +45,12 @@ func OPAMiddleware(
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if utils.Contains(routesToNotProxy, r.URL.RequestURI()) {
 				next.ServeHTTP(w, r)
+				return
+			}
+
+			rondSDK := sdkState.Get()
+			if rondSDK == nil {
+				utils.FailResponseWithCode(w, http.StatusServiceUnavailable, "asd", "dsa")
 				return
 			}
 

--- a/service/router.go
+++ b/service/router.go
@@ -26,6 +26,7 @@ import (
 	"github.com/rond-authz/rond/internal/config"
 	"github.com/rond-authz/rond/internal/utils"
 	"github.com/rond-authz/rond/openapi"
+	"github.com/rond-authz/rond/sdk"
 	"github.com/rond-authz/rond/sdk/inputuser"
 	"github.com/rond-authz/rond/types"
 
@@ -112,81 +113,10 @@ func SetupRouter(
 
 	completionChan := make(chan error, 1)
 
-	go func() {
+	go func(sdkBoot *SDKBootState) {
 		sdk := sdkBoot.Get()
-		if env.ExposeMetrics {
-			metricsRoute(router, registry)
-		}
-
-		log.Trace("register env variables middleware")
-		router.Use(config.RequestMiddlewareEnvironments(env))
-
-		evalRouter := router.NewRoute().Subrouter()
-		if env.Standalone {
-			swaggerRouter, err := swagger.NewRouter(gorilla.NewRouter(router), swagger.Options{
-				Context: context.Background(),
-				Openapi: &openapi3.T{
-					Info: &openapi3.Info{
-						Title:   serviceName,
-						Version: env.ServiceVersion,
-					},
-				},
-				JSONDocumentationPath: "/openapi/json",
-				YAMLDocumentationPath: "/openapi/yaml",
-			})
-			if err != nil {
-				completionChan <- err
-				return
-			}
-
-			// standalone routes
-			if _, err := swaggerRouter.AddRoute(http.MethodPost, "/revoke/bindings/resource/{resourceType}", revokeHandler, revokeDefinitions); err != nil {
-				completionChan <- err
-				return
-			}
-			if _, err := swaggerRouter.AddRoute(http.MethodPost, "/grant/bindings/resource/{resourceType}", grantHandler, grantDefinitions); err != nil {
-				completionChan <- err
-				return
-			}
-			if _, err := swaggerRouter.AddRoute(http.MethodPost, "/revoke/bindings", revokeHandler, revokeDefinitions); err != nil {
-				completionChan <- err
-				return
-			}
-			if _, err := swaggerRouter.AddRoute(http.MethodPost, "/grant/bindings", grantHandler, grantDefinitions); err != nil {
-				completionChan <- err
-				return
-			}
-
-			if err = swaggerRouter.GenerateAndExposeOpenapi(); err != nil {
-				completionChan <- err
-				return
-			}
-		}
-
-		log.Trace("register OPA middleware")
-		evalRouter.Use(OPAMiddleware(opaModuleConfig, sdk, routesToNotProxy, env.TargetServiceOASPath, &OPAMiddlewareOptions{
-			IsStandalone:         env.Standalone,
-			PathPrefixStandalone: env.PathPrefixStandalone,
-		}))
-
-		log.Trace("register input user client builder middleware")
-		if inputUserClient != nil {
-			evalRouter.Use(inputuser.ClientInjectorMiddleware(inputUserClient))
-		}
-
-		log.Trace("setup evaluation routes")
-		setupRoutes(evalRouter, oas, env)
-
-		//#nosec G104 -- Produces a false positive
-		router.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
-			path, _ := route.GetPathTemplate()
-			log.Tracef("Registered path: %s", path)
-			return nil
-		})
-
-		log.Trace("router setup completed")
-		completionChan <- nil
-	}()
+		setupSDKBasedRouter(router, serviceName, completionChan, log, env, opaModuleConfig, oas, sdk, inputUserClient, registry)
+	}(sdkBoot)
 
 	return router, completionChan
 }
@@ -244,4 +174,90 @@ func setupRoutes(router *mux.Router, oas *openapi.OpenAPISpec, env config.Enviro
 		fallbackRoute = fmt.Sprintf("%s/", path.Join(env.PathPrefixStandalone, fallbackRoute))
 	}
 	router.PathPrefix(fallbackRoute).HandlerFunc(rbacHandler)
+}
+
+func setupSDKBasedRouter(
+	router *mux.Router,
+	serviceName string,
+	completionChan chan error,
+	log *logrus.Logger,
+	env config.EnvironmentVariables,
+	opaModuleConfig *core.OPAModuleConfig,
+	oas *openapi.OpenAPISpec,
+	sdk sdk.OASEvaluatorFinder,
+	inputUserClient inputuser.Client,
+	registry *prometheus.Registry,
+) {
+	if env.ExposeMetrics {
+		metricsRoute(router, registry)
+	}
+
+	log.Trace("register env variables middleware")
+	router.Use(config.RequestMiddlewareEnvironments(env))
+
+	evalRouter := router.NewRoute().Subrouter()
+	if env.Standalone {
+		swaggerRouter, err := swagger.NewRouter(gorilla.NewRouter(router), swagger.Options{
+			Context: context.Background(),
+			Openapi: &openapi3.T{
+				Info: &openapi3.Info{
+					Title:   serviceName,
+					Version: env.ServiceVersion,
+				},
+			},
+			JSONDocumentationPath: "/openapi/json",
+			YAMLDocumentationPath: "/openapi/yaml",
+		})
+		if err != nil {
+			completionChan <- err
+			return
+		}
+
+		// standalone routes
+		if _, err := swaggerRouter.AddRoute(http.MethodPost, "/revoke/bindings/resource/{resourceType}", revokeHandler, revokeDefinitions); err != nil {
+			completionChan <- err
+			return
+		}
+		if _, err := swaggerRouter.AddRoute(http.MethodPost, "/grant/bindings/resource/{resourceType}", grantHandler, grantDefinitions); err != nil {
+			completionChan <- err
+			return
+		}
+		if _, err := swaggerRouter.AddRoute(http.MethodPost, "/revoke/bindings", revokeHandler, revokeDefinitions); err != nil {
+			completionChan <- err
+			return
+		}
+		if _, err := swaggerRouter.AddRoute(http.MethodPost, "/grant/bindings", grantHandler, grantDefinitions); err != nil {
+			completionChan <- err
+			return
+		}
+
+		if err = swaggerRouter.GenerateAndExposeOpenapi(); err != nil {
+			completionChan <- err
+			return
+		}
+	}
+
+	log.Trace("register OPA middleware")
+	evalRouter.Use(OPAMiddleware(opaModuleConfig, sdk, routesToNotProxy, env.TargetServiceOASPath, &OPAMiddlewareOptions{
+		IsStandalone:         env.Standalone,
+		PathPrefixStandalone: env.PathPrefixStandalone,
+	}))
+
+	log.Trace("register input user client builder middleware")
+	if inputUserClient != nil {
+		evalRouter.Use(inputuser.ClientInjectorMiddleware(inputUserClient))
+	}
+
+	log.Trace("setup evaluation routes")
+	setupRoutes(evalRouter, oas, env)
+
+	//#nosec G104 -- Produces a false positive
+	router.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
+		path, _ := route.GetPathTemplate()
+		log.Tracef("Registered path: %s", path)
+		return nil
+	})
+
+	log.Trace("router setup completed")
+	completionChan <- nil
 }

--- a/service/router.go
+++ b/service/router.go
@@ -110,7 +110,7 @@ func SetupRouter(
 	serviceName := "rönd"
 	StatusRoutes(router, serviceName, env.ServiceVersion)
 
-	errorChan := make(chan error, 1)
+	completionChan := make(chan error, 1)
 
 	go func() {
 		if env.ExposeMetrics {
@@ -134,31 +134,31 @@ func SetupRouter(
 				YAMLDocumentationPath: "/openapi/yaml",
 			})
 			if err != nil {
-				errorChan <- err
+				completionChan <- err
 				return
 			}
 
 			// standalone routes
 			if _, err := swaggerRouter.AddRoute(http.MethodPost, "/revoke/bindings/resource/{resourceType}", revokeHandler, revokeDefinitions); err != nil {
-				errorChan <- err
+				completionChan <- err
 				return
 				// return nil, err
 			}
 			if _, err := swaggerRouter.AddRoute(http.MethodPost, "/grant/bindings/resource/{resourceType}", grantHandler, grantDefinitions); err != nil {
-				errorChan <- err
+				completionChan <- err
 				return
 			}
 			if _, err := swaggerRouter.AddRoute(http.MethodPost, "/revoke/bindings", revokeHandler, revokeDefinitions); err != nil {
-				errorChan <- err
+				completionChan <- err
 				return
 			}
 			if _, err := swaggerRouter.AddRoute(http.MethodPost, "/grant/bindings", grantHandler, grantDefinitions); err != nil {
-				errorChan <- err
+				completionChan <- err
 				return
 			}
 
 			if err = swaggerRouter.GenerateAndExposeOpenapi(); err != nil {
-				errorChan <- err
+				completionChan <- err
 				return
 			}
 		}
@@ -185,10 +185,10 @@ func SetupRouter(
 		})
 
 		log.Trace("router setup completed")
-		errorChan <- nil
+		completionChan <- nil
 	}()
 
-	return router, errorChan
+	return router, completionChan
 }
 
 func setupRoutes(router *mux.Router, oas *openapi.OpenAPISpec, env config.EnvironmentVariables) {

--- a/service/router.go
+++ b/service/router.go
@@ -122,12 +122,6 @@ func SetupRouter(
 		return nil
 	})
 	log.Trace("router setup completed")
-
-	// go func(sdkBoot *SDKBootState) {
-	// 	sdk := sdkBoot.Get()
-	// setupSDKBasedRouter(router, serviceName, completionChan, log, env, opaModuleConfig, oas, sdkBoot, inputUserClient, registry)
-	// }(sdkBoot)
-
 	return router, nil
 }
 
@@ -254,89 +248,3 @@ func setupServiceRouter(
 	setupEvalRoutes(evalRouter, oas, env)
 	return nil
 }
-
-// func setupSDKBasedRouter(
-// 	router *mux.Router,
-// 	serviceName string,
-// 	completionChan chan error,
-// 	log *logrus.Logger,
-// 	env config.EnvironmentVariables,
-// 	opaModuleConfig *core.OPAModuleConfig,
-// 	oas *openapi.OpenAPISpec,
-// 	sdkBootState *SDKBootState,
-// 	inputUserClient inputuser.Client,
-// 	registry *prometheus.Registry,
-// ) {
-// 	if env.ExposeMetrics {
-// 		metricsRoute(router, registry)
-// 	}
-
-// 	log.Trace("register env variables middleware")
-// 	router.Use(config.RequestMiddlewareEnvironments(env))
-
-// 	evalRouter := router.NewRoute().Subrouter()
-// 	if env.Standalone {
-// 		swaggerRouter, err := swagger.NewRouter(gorilla.NewRouter(router), swagger.Options{
-// 			Context: context.Background(),
-// 			Openapi: &openapi3.T{
-// 				Info: &openapi3.Info{
-// 					Title:   serviceName,
-// 					Version: env.ServiceVersion,
-// 				},
-// 			},
-// 			JSONDocumentationPath: "/openapi/json",
-// 			YAMLDocumentationPath: "/openapi/yaml",
-// 		})
-// 		if err != nil {
-// 			completionChan <- err
-// 			return
-// 		}
-
-// 		// standalone routes
-// 		if _, err := swaggerRouter.AddRoute(http.MethodPost, "/revoke/bindings/resource/{resourceType}", revokeHandler, revokeDefinitions); err != nil {
-// 			completionChan <- err
-// 			return
-// 		}
-// 		if _, err := swaggerRouter.AddRoute(http.MethodPost, "/grant/bindings/resource/{resourceType}", grantHandler, grantDefinitions); err != nil {
-// 			completionChan <- err
-// 			return
-// 		}
-// 		if _, err := swaggerRouter.AddRoute(http.MethodPost, "/revoke/bindings", revokeHandler, revokeDefinitions); err != nil {
-// 			completionChan <- err
-// 			return
-// 		}
-// 		if _, err := swaggerRouter.AddRoute(http.MethodPost, "/grant/bindings", grantHandler, grantDefinitions); err != nil {
-// 			completionChan <- err
-// 			return
-// 		}
-
-// 		if err = swaggerRouter.GenerateAndExposeOpenapi(); err != nil {
-// 			completionChan <- err
-// 			return
-// 		}
-// 	}
-
-// 	log.Trace("register OPA middleware")
-// 	evalRouter.Use(OPAMiddleware(opaModuleConfig, sdkBootState, routesToNotProxy, env.TargetServiceOASPath, &OPAMiddlewareOptions{
-// 		IsStandalone:         env.Standalone,
-// 		PathPrefixStandalone: env.PathPrefixStandalone,
-// 	}))
-
-// 	log.Trace("register input user client builder middleware")
-// 	if inputUserClient != nil {
-// 		evalRouter.Use(inputuser.ClientInjectorMiddleware(inputUserClient))
-// 	}
-
-// 	log.Trace("setup evaluation routes")
-// 	setupEvalRoutes(evalRouter, oas, env)
-
-// 	//#nosec G104 -- Produces a false positive
-// 	router.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
-// 		path, _ := route.GetPathTemplate()
-// 		log.Tracef("Registered path: %s", path)
-// 		return nil
-// 	})
-
-// 	log.Trace("router setup completed")
-// 	completionChan <- nil
-// }

--- a/service/router_test.go
+++ b/service/router_test.go
@@ -88,7 +88,7 @@ func TestSetupRoutes(t *testing.T) {
 			"/{/with/trailing/slash:/with/trailing/slash\\/?}",
 		}
 
-		setupRoutes(router, oas, envs)
+		setupEvalRoutes(router, oas, envs)
 
 		foundPaths := make([]string, 0)
 		router.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
@@ -132,7 +132,7 @@ func TestSetupRoutes(t *testing.T) {
 		}
 		sort.Strings(expectedPaths)
 
-		setupRoutes(router, oas, envs)
+		setupEvalRoutes(router, oas, envs)
 
 		foundPaths := make([]string, 0)
 		router.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
@@ -168,7 +168,7 @@ func TestSetupRoutes(t *testing.T) {
 		expectedPaths := []string{"/validate/", "/validate/documentation/json", "/validate/foo/", "/validate/foo/bar/", "/validate/foo/bar/nested", "/validate/foo/bar/{barId}"}
 		sort.Strings(expectedPaths)
 
-		setupRoutes(router, oas, envs)
+		setupEvalRoutes(router, oas, envs)
 
 		foundPaths := make([]string, 0)
 		router.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
@@ -333,7 +333,7 @@ func TestSetupRoutesIntegration(t *testing.T) {
 		defer server.Close()
 
 		router := mux.NewRouter()
-		setupRoutes(router, oas, envs)
+		setupEvalRoutes(router, oas, envs)
 
 		serverURL, _ := url.Parse(server.URL)
 
@@ -373,7 +373,7 @@ func TestSetupRoutesIntegration(t *testing.T) {
 		serverURL, _ := url.Parse(server.URL)
 
 		router := mux.NewRouter()
-		setupRoutes(router, oas, envs)
+		setupEvalRoutes(router, oas, envs)
 
 		eval, err := openapi.SetupEvaluators(ctx, logger, oas, mockOPAModule, nil)
 		require.NoError(t, err)
@@ -412,7 +412,7 @@ func TestSetupRoutesIntegration(t *testing.T) {
 		todo { false }`,
 		}
 		router := mux.NewRouter()
-		setupRoutes(router, oas, envs)
+		setupEvalRoutes(router, oas, envs)
 
 		evaluator := getEvaluator(t, ctx, mockOPAModule, nil, oas, http.MethodGet, "/users/", nil)
 
@@ -439,7 +439,7 @@ func TestSetupRoutesIntegration(t *testing.T) {
 
 	t.Run("blocks request on policy evaluation error", func(t *testing.T) {
 		router := mux.NewRouter()
-		setupRoutes(router, oas, envs)
+		setupEvalRoutes(router, oas, envs)
 
 		evaluator := fake.NewSDKEvaluator(nil, mockXPermission, &fake.RequestPolicyEvaluatorResult{
 			Err: fmt.Errorf("fails to evaluate policy"),
@@ -482,7 +482,7 @@ func TestSetupRoutesIntegration(t *testing.T) {
 		defer server.Close()
 
 		router := mux.NewRouter()
-		setupRoutes(router, oas, envs)
+		setupEvalRoutes(router, oas, envs)
 
 		serverURL, _ := url.Parse(server.URL)
 
@@ -525,7 +525,7 @@ func TestSetupRoutesIntegration(t *testing.T) {
 		defer server.Close()
 
 		router := mux.NewRouter()
-		setupRoutes(router, oas, envs)
+		setupEvalRoutes(router, oas, envs)
 
 		serverURL, _ := url.Parse(server.URL)
 

--- a/service/sdkbootstate.go
+++ b/service/sdkbootstate.go
@@ -1,0 +1,42 @@
+// Copyright 2023 Mia srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"sync"
+
+	"github.com/rond-authz/rond/sdk"
+)
+
+type SDKBootState struct {
+	wg   *sync.WaitGroup
+	rond sdk.OASEvaluatorFinder
+}
+
+func NewSDKBootState() *SDKBootState {
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	return &SDKBootState{wg: wg}
+}
+
+func (s *SDKBootState) Get() sdk.OASEvaluatorFinder {
+	s.wg.Wait()
+	return s.rond
+}
+
+func (s *SDKBootState) Ready(rond sdk.OASEvaluatorFinder) {
+	s.rond = rond
+	s.wg.Done()
+}

--- a/service/sdkbootstate.go
+++ b/service/sdkbootstate.go
@@ -21,30 +21,18 @@ import (
 )
 
 type SDKBootState struct {
-	// wg   *sync.WaitGroup
 	mtx  *sync.Mutex
 	rond sdk.OASEvaluatorFinder
 }
 
 func NewSDKBootState() *SDKBootState {
-	// wg := &sync.WaitGroup{}
-	// wg.Add(1)
-	return &SDKBootState{
-		// wg: wg,
-		mtx: &sync.Mutex{},
-	}
+	return &SDKBootState{mtx: &sync.Mutex{}}
 }
-
-// func (s *SDKBootState) Wait() sdk.OASEvaluatorFinder {
-// 	s.wg.Wait()
-// 	return s.rond
-// }
 
 func (s *SDKBootState) Ready(rond sdk.OASEvaluatorFinder) {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 	s.rond = rond
-	// s.wg.Done()
 }
 
 func (s *SDKBootState) Get() sdk.OASEvaluatorFinder {

--- a/service/sdkbootstate.go
+++ b/service/sdkbootstate.go
@@ -21,22 +21,34 @@ import (
 )
 
 type SDKBootState struct {
-	wg   *sync.WaitGroup
+	// wg   *sync.WaitGroup
+	mtx  *sync.Mutex
 	rond sdk.OASEvaluatorFinder
 }
 
 func NewSDKBootState() *SDKBootState {
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
-	return &SDKBootState{wg: wg}
+	// wg := &sync.WaitGroup{}
+	// wg.Add(1)
+	return &SDKBootState{
+		// wg: wg,
+		mtx: &sync.Mutex{},
+	}
+}
+
+// func (s *SDKBootState) Wait() sdk.OASEvaluatorFinder {
+// 	s.wg.Wait()
+// 	return s.rond
+// }
+
+func (s *SDKBootState) Ready(rond sdk.OASEvaluatorFinder) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	s.rond = rond
+	// s.wg.Done()
 }
 
 func (s *SDKBootState) Get() sdk.OASEvaluatorFinder {
-	s.wg.Wait()
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
 	return s.rond
-}
-
-func (s *SDKBootState) Ready(rond sdk.OASEvaluatorFinder) {
-	s.rond = rond
-	s.wg.Done()
 }

--- a/service/sdkbootstate_test.go
+++ b/service/sdkbootstate_test.go
@@ -1,0 +1,21 @@
+// Copyright 2023 Mia srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+// func TestSDKBootState(t *testing.T) {
+// 	sdkBootState := NewSDKBootState()
+
+// 	t.Run()
+// }

--- a/service/sdkbootstate_test.go
+++ b/service/sdkbootstate_test.go
@@ -25,14 +25,12 @@ func TestSDKBootState(t *testing.T) {
 	sdkBootState := NewSDKBootState()
 
 	t.Run("flow with routine", func(t *testing.T) {
-		completed := make(chan bool, 1)
-		go func() {
-			sdkBootState.Ready(fake.SDKEvaluatorFinder{})
-			completed <- true
-		}()
-
 		sdk := sdkBootState.Get()
+		require.Nil(t, sdk)
+
+		sdkBootState.Ready(fake.SDKEvaluatorFinder{})
+
+		sdk = sdkBootState.Get()
 		require.NotNil(t, sdk)
-		require.True(t, <-completed)
 	})
 }

--- a/service/statusroutes.go
+++ b/service/statusroutes.go
@@ -17,6 +17,7 @@ package service
 import (
 	"encoding/json"
 	"net/http"
+	"sync"
 
 	"github.com/rond-authz/rond/internal/utils"
 
@@ -25,6 +26,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+var statusRoutes = []string{"/-/rbac-healthz", "/-/rbac-ready", "/-/rbac-check-up"}
+
 // StatusResponse type.
 type StatusResponse struct {
 	Status  string `json:"status"`
@@ -32,40 +35,78 @@ type StatusResponse struct {
 	Version string `json:"version"`
 }
 
-func handleStatusRoutes(w http.ResponseWriter, serviceName, serviceVersion string) (*StatusResponse, []byte) {
+func sendStatusRoutes(w http.ResponseWriter, logger *logrus.Entry, ok bool, serviceName, serviceVersion string) {
+	statusMessage := "OK"
+	statusCode := http.StatusOK
+	if !ok {
+		statusMessage = "KO"
+		statusCode = http.StatusServiceUnavailable
+	}
+
 	w.Header().Add(utils.ContentTypeHeaderKey, utils.JSONContentTypeHeader)
 	status := StatusResponse{
-		Status:  "OK",
+		Status:  statusMessage,
 		Name:    serviceName,
 		Version: serviceVersion,
 	}
 	body, err := json.Marshal(&status)
 	if err != nil {
 		w.WriteHeader(http.StatusServiceUnavailable)
-		return nil, nil
+		return
 	}
 
-	return &status, body
+	w.WriteHeader(statusCode)
+	if _, err := w.Write(body); err != nil {
+		logger.WithField("error", logrus.Fields{"message": err.Error()}).Warn("failed response write")
+	}
 }
 
-var statusRoutes = []string{"/-/rbac-healthz", "/-/rbac-ready", "/-/rbac-check-up"}
-
-func handleStatusEndpoint(serviceName, serviceVersion string) func(http.ResponseWriter, *http.Request) {
+func handleOKHandler(serviceName, serviceVersion string) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, req *http.Request) {
-		_, body := handleStatusRoutes(w, serviceName, serviceVersion)
-		if _, err := w.Write(body); err != nil {
-			logger := glogrus.FromContext(req.Context())
-			logger.WithField("error", logrus.Fields{"message": err.Error()}).Warn("failed response write")
-		}
+		sendStatusRoutes(
+			w,
+			glogrus.FromContext(req.Context()),
+			true,
+			serviceName,
+			serviceVersion,
+		)
+	}
+}
+
+func handleSDKReadyHandler(sdkBoot *SDKBootState, serviceName, serviceVersion string) func(http.ResponseWriter, *http.Request) {
+	readyFlagLock := &sync.Mutex{}
+
+	sdkReady := false
+	go func(sdkBoot *SDKBootState, readyFlagLock *sync.Mutex) {
+		readyFlagLock.Lock()
+		defer readyFlagLock.Unlock()
+
+		sdkBoot.Get()
+		sdkReady = true
+	}(sdkBoot, readyFlagLock)
+
+	return func(w http.ResponseWriter, req *http.Request) {
+		readyFlagLock.Lock()
+		defer readyFlagLock.Unlock()
+
+		sendStatusRoutes(
+			w,
+			glogrus.FromContext(req.Context()),
+			sdkReady,
+			serviceName,
+			serviceVersion,
+		)
 	}
 }
 
 // StatusRoutes add status routes to router.
-func StatusRoutes(r *mux.Router, serviceName, serviceVersion string) {
-	statusEndpointHandler := handleStatusEndpoint(serviceName, serviceVersion)
-	r.HandleFunc("/-/rbac-healthz", statusEndpointHandler)
+func StatusRoutes(r *mux.Router, sdkBoot *SDKBootState, serviceName, serviceVersion string) {
+	sdkReadyHandler := handleSDKReadyHandler(sdkBoot, serviceName, serviceVersion)
+	alwaysOKHandler := handleOKHandler(serviceName, serviceVersion)
 
-	r.HandleFunc("/-/rbac-ready", statusEndpointHandler)
+	r.HandleFunc("/-/rbac-healthz", alwaysOKHandler)
 
-	r.HandleFunc("/-/rbac-check-up", statusEndpointHandler)
+	r.HandleFunc("/-/rbac-ready", sdkReadyHandler)
+
+	r.HandleFunc("/-/rbac-check-up", alwaysOKHandler)
 }

--- a/service/statusroutes.go
+++ b/service/statusroutes.go
@@ -78,10 +78,10 @@ func handleSDKReadyHandler(sdkBoot *SDKBootState, serviceName, serviceVersion st
 
 	sdkReady := false
 	go func(sdkBoot *SDKBootState, readyFlagLock *sync.Mutex) {
+		sdkBoot.Get()
+
 		readyFlagLock.Lock()
 		defer readyFlagLock.Unlock()
-
-		sdkBoot.Get()
 		sdkReady = true
 	}(sdkBoot, readyFlagLock)
 

--- a/service/statusroutes_test.go
+++ b/service/statusroutes_test.go
@@ -129,7 +129,6 @@ func TestStatusRoutesIntegration(t *testing.T) {
 			PathPrefixStandalone: "/my-prefix",
 		}
 		router, err := SetupRouter(log, env, opa, oas, sdkState, nil, nil)
-		// err := <-completionChan
 		require.NoError(t, err, "unexpected error")
 
 		t.Run("/-/rbac-ready", func(t *testing.T) {
@@ -165,7 +164,6 @@ func TestStatusRoutesIntegration(t *testing.T) {
 			ServiceVersion:       "latest",
 		}
 		router, err := SetupRouter(log, env, opa, oas, sdkState, nil, nil)
-		// err := <-completionChan
 		require.NoError(t, err, "unexpected error")
 		t.Run("/-/rbac-ready", func(t *testing.T) {
 			w := httptest.NewRecorder()

--- a/service/statusroutes_test.go
+++ b/service/statusroutes_test.go
@@ -128,8 +128,8 @@ func TestStatusRoutesIntegration(t *testing.T) {
 			TargetServiceHost:    "my-service:4444",
 			PathPrefixStandalone: "/my-prefix",
 		}
-		router, completionChan := SetupRouter(log, env, opa, oas, sdkState, nil, nil)
-		err := <-completionChan
+		router, err := SetupRouter(log, env, opa, oas, sdkState, nil, nil)
+		// err := <-completionChan
 		require.NoError(t, err, "unexpected error")
 
 		t.Run("/-/rbac-ready", func(t *testing.T) {
@@ -164,8 +164,8 @@ func TestStatusRoutesIntegration(t *testing.T) {
 			PathPrefixStandalone: "/my-prefix",
 			ServiceVersion:       "latest",
 		}
-		router, completionChan := SetupRouter(log, env, opa, oas, sdkState, nil, nil)
-		err := <-completionChan
+		router, err := SetupRouter(log, env, opa, oas, sdkState, nil, nil)
+		// err := <-completionChan
 		require.NoError(t, err, "unexpected error")
 		t.Run("/-/rbac-ready", func(t *testing.T) {
 			w := httptest.NewRecorder()

--- a/service/statusroutes_test.go
+++ b/service/statusroutes_test.go
@@ -117,7 +117,8 @@ test_policy { true }
 			TargetServiceHost:    "my-service:4444",
 			PathPrefixStandalone: "/my-prefix",
 		}
-		router, err := SetupRouter(log, env, opa, oas, sdk, nil, nil)
+		router, completionChan := SetupRouter(log, env, opa, oas, sdk, nil, nil)
+		err := <-completionChan
 		require.NoError(t, err, "unexpected error")
 
 		t.Run("/-/rbac-ready", func(t *testing.T) {
@@ -150,7 +151,8 @@ test_policy { true }
 			PathPrefixStandalone: "/my-prefix",
 			ServiceVersion:       "latest",
 		}
-		router, err := SetupRouter(log, env, opa, oas, sdk, nil, nil)
+		router, completionChan := SetupRouter(log, env, opa, oas, sdk, nil, nil)
+		err := <-completionChan
 		require.NoError(t, err, "unexpected error")
 		t.Run("/-/rbac-ready", func(t *testing.T) {
 			w := httptest.NewRecorder()

--- a/service/statusroutes_test.go
+++ b/service/statusroutes_test.go
@@ -89,7 +89,7 @@ func TestStatusRoutes(t *testing.T) {
 
 		testRouter.ServeHTTP(responseRecorder, request)
 		statusCode := responseRecorder.Result().StatusCode
-		require.Equal(t, http.StatusOK, statusCode, "The response statusCode should be 200")
+		require.Equal(t, http.StatusServiceUnavailable, statusCode, "The response statusCode should be 200")
 
 		rawBody := responseRecorder.Result().Body
 		body, readBodyError := io.ReadAll(rawBody)

--- a/service/statusroutes_test.go
+++ b/service/statusroutes_test.go
@@ -32,13 +32,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestStatusRoutes(testCase *testing.T) {
+func TestStatusRoutes(t *testing.T) {
 	testRouter := mux.NewRouter()
 	serviceName := "my-service-name"
 	serviceVersion := "0.0.0"
-	StatusRoutes(testRouter, serviceName, serviceVersion)
 
-	testCase.Run("/-/rbac-healthz - ok", func(t *testing.T) {
+	rondSDK, err := sdk.NewFromOAS(context.Background(), opa, oas, &sdk.Options{})
+	require.NoError(t, err, "unexpected error")
+	sdkState := NewSDKBootState()
+	sdkState.Ready(rondSDK)
+
+	StatusRoutes(testRouter, sdkState, serviceName, serviceVersion)
+
+	t.Run("/-/rbac-healthz - ok", func(t *testing.T) {
 		expectedResponse := fmt.Sprintf("{\"status\":\"OK\",\"name\":\"%s\",\"version\":\"%s\"}", serviceName, serviceVersion)
 		responseRecorder := httptest.NewRecorder()
 		request, requestError := http.NewRequest(http.MethodGet, "/-/rbac-healthz", nil)
@@ -54,7 +60,7 @@ func TestStatusRoutes(testCase *testing.T) {
 		require.Equal(t, expectedResponse, string(body), "The response body should be the expected one")
 	})
 
-	testCase.Run("/-/rbac-ready - ok", func(t *testing.T) {
+	t.Run("/-/rbac-ready - ok", func(t *testing.T) {
 		expectedResponse := fmt.Sprintf("{\"status\":\"OK\",\"name\":\"%s\",\"version\":\"%s\"}", serviceName, serviceVersion)
 		responseRecorder := httptest.NewRecorder()
 		request, requestError := http.NewRequest(http.MethodGet, "/-/rbac-ready", nil)
@@ -70,7 +76,28 @@ func TestStatusRoutes(testCase *testing.T) {
 		require.Equal(t, expectedResponse, string(body), "The response body should be the expected one")
 	})
 
-	testCase.Run("/-/rbac-check-up - ok", func(t *testing.T) {
+	t.Run("/-/rbac-ready - ko if sdk not ready", func(t *testing.T) {
+		testRouter := mux.NewRouter()
+		sdkState := NewSDKBootState()
+
+		StatusRoutes(testRouter, sdkState, serviceName, serviceVersion)
+
+		expectedResponse := fmt.Sprintf("{\"status\":\"KO\",\"name\":\"%s\",\"version\":\"%s\"}", serviceName, serviceVersion)
+		responseRecorder := httptest.NewRecorder()
+		request, requestError := http.NewRequest(http.MethodGet, "/-/rbac-ready", nil)
+		require.NoError(t, requestError, "Error creating the /-/rbac-ready request")
+
+		testRouter.ServeHTTP(responseRecorder, request)
+		statusCode := responseRecorder.Result().StatusCode
+		require.Equal(t, http.StatusOK, statusCode, "The response statusCode should be 200")
+
+		rawBody := responseRecorder.Result().Body
+		body, readBodyError := io.ReadAll(rawBody)
+		require.NoError(t, readBodyError)
+		require.Equal(t, expectedResponse, string(body), "The response body should be the expected one")
+	})
+
+	t.Run("/-/rbac-check-up - ok", func(t *testing.T) {
 		expectedResponse := fmt.Sprintf("{\"status\":\"OK\",\"name\":\"%s\",\"version\":\"%s\"}", serviceName, serviceVersion)
 		responseRecorder := httptest.NewRecorder()
 		request, requestError := http.NewRequest(http.MethodGet, "/-/rbac-check-up", nil)
@@ -90,34 +117,18 @@ func TestStatusRoutes(testCase *testing.T) {
 func TestStatusRoutesIntegration(t *testing.T) {
 	log, _ := test.NewNullLogger()
 
-	opa := &core.OPAModuleConfig{
-		Name: "policies",
-		Content: `package policies
-test_policy { true }
-`,
-	}
-	oas := &openapi.OpenAPISpec{
-		Paths: openapi.OpenAPIPaths{
-			"/evalapi": openapi.PathVerbs{
-				"get": openapi.VerbConfig{
-					PermissionV1: &openapi.XPermission{
-						AllowPermission: "test_policy",
-					},
-				},
-			},
-		},
-	}
-
-	sdk, err := sdk.NewFromOAS(context.Background(), opa, oas, &sdk.Options{})
+	rondSDK, err := sdk.NewFromOAS(context.Background(), opa, oas, &sdk.Options{})
 	require.NoError(t, err, "unexpected error")
 
 	t.Run("non standalone", func(t *testing.T) {
+		sdkState := NewSDKBootState()
+		sdkState.Ready(rondSDK)
 		env := config.EnvironmentVariables{
 			Standalone:           false,
 			TargetServiceHost:    "my-service:4444",
 			PathPrefixStandalone: "/my-prefix",
 		}
-		router, completionChan := SetupRouter(log, env, opa, oas, sdk, nil, nil)
+		router, completionChan := SetupRouter(log, env, opa, oas, sdkState, nil, nil)
 		err := <-completionChan
 		require.NoError(t, err, "unexpected error")
 
@@ -145,13 +156,15 @@ test_policy { true }
 	})
 
 	t.Run("standalone", func(t *testing.T) {
+		sdkState := NewSDKBootState()
+		sdkState.Ready(rondSDK)
 		env := config.EnvironmentVariables{
 			Standalone:           true,
 			TargetServiceHost:    "my-service:4444",
 			PathPrefixStandalone: "/my-prefix",
 			ServiceVersion:       "latest",
 		}
-		router, completionChan := SetupRouter(log, env, opa, oas, sdk, nil, nil)
+		router, completionChan := SetupRouter(log, env, opa, oas, sdkState, nil, nil)
 		err := <-completionChan
 		require.NoError(t, err, "unexpected error")
 		t.Run("/-/rbac-ready", func(t *testing.T) {
@@ -176,4 +189,23 @@ test_policy { true }
 			require.Equal(t, http.StatusOK, w.Result().StatusCode)
 		})
 	})
+}
+
+var opa = &core.OPAModuleConfig{
+	Name: "policies",
+	Content: `package policies
+test_policy { true }
+`,
+}
+
+var oas = &openapi.OpenAPISpec{
+	Paths: openapi.OpenAPIPaths{
+		"/evalapi": openapi.PathVerbs{
+			"get": openapi.VerbConfig{
+				PermissionV1: &openapi.XPermission{
+					AllowPermission: "test_policy",
+				},
+			},
+		},
+	},
 }


### PR DESCRIPTION
This PR introduces changes to make status routes reply asap providing meaningful setup status, in particular:

 - liveness: immediately OK, se service is alive since the web server is up!
 - readiness: replies immediately, KO until SDK is ready, then returns OK
 - check-up: acts as the liveness (do we still need this route? 🤔)