### PR TITLE
feat(#273): support for preventBodyLoad in request flow

### DIFF
--- a/core/opaevaluator.go
+++ b/core/opaevaluator.go
@@ -45,9 +45,10 @@ type QueryOptions struct {
 }
 
 type RequestFlow struct {
-	PolicyName    string       `json:"policyName"`
-	GenerateQuery bool         `json:"generateQuery"`
-	QueryOptions  QueryOptions `json:"queryOptions"`
+	PolicyName      string       `json:"policyName"`
+	GenerateQuery   bool         `json:"generateQuery"`
+	QueryOptions    QueryOptions `json:"queryOptions"`
+	PreventBodyLoad bool         `json:"preventBodyLoad"`
 }
 
 type ResponseFlow struct {

--- a/mocks/nestedPathsConfig.json
+++ b/mocks/nestedPathsConfig.json
@@ -167,7 +167,8 @@
             "get": {
               "x-rond": {
                 "requestFlow": {
-                  "policyName": "foo_bar"
+                  "policyName": "foo_bar",
+                  "preventBodyLoad": true
                 },
                 "responseFlow": {
                   "policyName": "original_path"

--- a/mocks/nestedPathsConfig.json
+++ b/mocks/nestedPathsConfig.json
@@ -179,6 +179,16 @@
               }
             }
         },
+        "/with/preventbodyload": {
+            "get": {
+              "x-rond": {
+                "requestFlow": {
+                  "policyName": "foo_bar",
+                  "preventBodyLoad": true
+                }
+              }
+            }
+        },
         "/without/trailing/slash": {
             "post": {
               "x-rond": {

--- a/openapi/openapi_utils.go
+++ b/openapi/openapi_utils.go
@@ -132,6 +132,7 @@ func createOasHandler(scopedMethodContent VerbConfig, oasPathCleaned string) fun
 		header.Set("resourceFilter.rowFilter.headerKey", permission.RequestFlow.QueryOptions.HeaderName)
 		header.Set("responseFilter.policy", permission.ResponseFlow.PolicyName)
 		header.Set("options.enableResourcePermissionsMapOptimization", strconv.FormatBool(permission.Options.EnableResourcePermissionsMapOptimization))
+		header.Set("requestFlow.preventBodyLoad", strconv.FormatBool(permission.RequestFlow.PreventBodyLoad))
 		header.Set("options.ignoreTrailingSlash", strconv.FormatBool(permission.Options.IgnoreTrailingSlash))
 		header.Set("pathTemplate", oasPathCleaned)
 	}
@@ -217,10 +218,15 @@ func (oas *OpenAPISpec) FindPermission(OASRouter *bunrouter.CompatRouter, path s
 	if err != nil {
 		return core.RondConfig{}, routerInfo, fmt.Errorf("error while parsing options.ignoreTrailingSlash: %s", err)
 	}
+	preventRequestBodyLoad, err := strconv.ParseBool(recorderResult.Header.Get("requestFlow.preventBodyLoad"))
+	if err != nil {
+		return core.RondConfig{}, routerInfo, fmt.Errorf("error while parsing requestFlow.preventBodyLoad")
+	}
 	return core.RondConfig{
 		RequestFlow: core.RequestFlow{
-			PolicyName:    recorderResult.Header.Get("allow"),
-			GenerateQuery: rowFilterEnabled,
+			PolicyName:      recorderResult.Header.Get("allow"),
+			GenerateQuery:   rowFilterEnabled,
+			PreventBodyLoad: preventRequestBodyLoad,
 			QueryOptions: core.QueryOptions{
 				HeaderName: recorderResult.Header.Get("resourceFilter.rowFilter.headerKey"),
 			},

--- a/openapi/openapi_utils_test.go
+++ b/openapi/openapi_utils_test.go
@@ -567,6 +567,17 @@ func TestFindPermission(t *testing.T) {
 			RequestedPath: "/ignore/trailing/slash/",
 			Method:        "GET",
 		}, matchedPath)
+
+		found, matchedPath, err = oas.FindPermission(OASRouter, "/with/preventbodyload", "GET")
+		require.NoError(t, err)
+		require.Equal(t, core.RondConfig{
+			RequestFlow: core.RequestFlow{PolicyName: "foo_bar", PreventBodyLoad: true},
+		}, found)
+		require.Equal(t, RouterInfo{
+			MatchedPath:   "/with/preventbodyload",
+			RequestedPath: "/with/preventbodyload",
+			Method:        "GET",
+		}, matchedPath)
 	})
 
 	t.Run("encoded cases", func(t *testing.T) {

--- a/openapi/openapi_utils_test.go
+++ b/openapi/openapi_utils_test.go
@@ -554,6 +554,19 @@ func TestFindPermission(t *testing.T) {
 			RequestedPath: "/without/trailing/slash/",
 			Method:        "POST",
 		}, matchedPath)
+
+		found, matchedPath, err = oas.FindPermission(OASRouter, "/ignore/trailing/slash/", "GET")
+		require.NoError(t, err)
+		require.Equal(t, core.RondConfig{
+			RequestFlow:  core.RequestFlow{PolicyName: "foo_bar", PreventBodyLoad: true},
+			ResponseFlow: core.ResponseFlow{PolicyName: "original_path"},
+			Options:      core.PermissionOptions{IgnoreTrailingSlash: true},
+		}, found)
+		require.Equal(t, RouterInfo{
+			MatchedPath:   "/ignore/trailing/slash/",
+			RequestedPath: "/ignore/trailing/slash/",
+			Method:        "GET",
+		}, matchedPath)
 	})
 
 	t.Run("encoded cases", func(t *testing.T) {

--- a/service/handler.go
+++ b/service/handler.go
@@ -113,7 +113,7 @@ func EvaluateRequest(
 
 	permission := evaluatorSdk.Config()
 
-	rondInput, err := rondhttp.NewInput(req, env.ClientTypeHeader, mux.Vars(req), rondInputUser, nil)
+	rondInput, err := rondhttp.NewInput(&permission, req, env.ClientTypeHeader, mux.Vars(req), rondInputUser, nil)
 	if err != nil {
 		logger.WithField("error", logrus.Fields{"message": err.Error()}).Error("failed to create rond input")
 		utils.FailResponseWithCode(w, http.StatusInternalServerError, "failed to create rond input", utils.GENERIC_BUSINESS_ERROR_MESSAGE)
@@ -196,6 +196,7 @@ func ReverseProxy(
 	proxy.Transport = NewOPATransport(
 		http.DefaultTransport,
 		req.Context(),
+		permission,
 		logger,
 		req,
 

--- a/service/handler.go
+++ b/service/handler.go
@@ -111,9 +111,9 @@ func EvaluateRequest(
 ) error {
 	logger := glogrus.FromContext(req.Context())
 
-	permission := evaluatorSdk.Config()
+	evaluationConfig := evaluatorSdk.Config()
 
-	rondInput, err := rondhttp.NewInput(&permission, req, env.ClientTypeHeader, mux.Vars(req), rondInputUser, nil)
+	rondInput, err := rondhttp.NewInput(&evaluationConfig, req, env.ClientTypeHeader, mux.Vars(req), rondInputUser, nil)
 	if err != nil {
 		logger.WithField("error", logrus.Fields{"message": err.Error()}).Error("failed to create rond input")
 		utils.FailResponseWithCode(w, http.StatusInternalServerError, "failed to create rond input", utils.GENERIC_BUSINESS_ERROR_MESSAGE)
@@ -153,8 +153,8 @@ func EvaluateRequest(
 	}
 
 	queryHeaderKey := BASE_ROW_FILTER_HEADER_KEY
-	if permission.RequestFlow.QueryOptions.HeaderName != "" {
-		queryHeaderKey = permission.RequestFlow.QueryOptions.HeaderName
+	if evaluationConfig.RequestFlow.QueryOptions.HeaderName != "" {
+		queryHeaderKey = evaluationConfig.RequestFlow.QueryOptions.HeaderName
 	}
 	if result.QueryToProxy != nil {
 		req.Header.Set(queryHeaderKey, string(result.QueryToProxy))

--- a/service/opa_transport.go
+++ b/service/opa_transport.go
@@ -44,6 +44,7 @@ type OPATransport struct {
 	// FIXME: this overlaps with the req.Context used during RoundTrip.
 	context context.Context
 	logger  *logrus.Entry
+	config  *core.RondConfig
 	request *http.Request
 
 	clientHeaderKey string
@@ -54,6 +55,7 @@ type OPATransport struct {
 func NewOPATransport(
 	transport http.RoundTripper,
 	context context.Context,
+	config *core.RondConfig,
 	logger *logrus.Entry,
 	req *http.Request,
 	clientHeaderKey string,
@@ -64,6 +66,7 @@ func NewOPATransport(
 		RoundTripper: transport,
 		context:      req.Context(),
 		logger:       logger,
+		config:       config,
 		request:      req,
 
 		user:            user,
@@ -110,7 +113,7 @@ func (t *OPATransport) RoundTrip(req *http.Request) (resp *http.Response, err er
 	}
 
 	pathParams := mux.Vars(t.request)
-	input, err := rondhttp.NewInput(t.request, t.clientHeaderKey, pathParams, t.user, decodedBody)
+	input, err := rondhttp.NewInput(t.config, t.request, t.clientHeaderKey, pathParams, t.user, decodedBody)
 	if err != nil {
 		t.responseWithError(resp, err, http.StatusInternalServerError)
 		return resp, nil

--- a/service/opa_transport_test.go
+++ b/service/opa_transport_test.go
@@ -40,6 +40,7 @@ import (
 )
 
 func TestRoundTripErrors(t *testing.T) {
+	config := &core.RondConfig{}
 	logger, _ := test.NewNullLogger()
 
 	defer gock.Off()
@@ -58,6 +59,7 @@ func TestRoundTripErrors(t *testing.T) {
 		transport := NewOPATransport(
 			http.DefaultTransport,
 			req.Context(),
+			config,
 			logrus.NewEntry(logger),
 			req,
 			"",
@@ -89,12 +91,14 @@ func TestIs2xx(t *testing.T) {
 
 func TestOPATransportResponseWithError(t *testing.T) {
 	logger, _ := test.NewNullLogger()
+	config := &core.RondConfig{}
 
 	req := httptest.NewRequest(http.MethodPost, "http://example.com/some-api", nil)
 
 	transport := NewOPATransport(
 		http.DefaultTransport,
 		req.Context(),
+		config,
 		logrus.NewEntry(logger),
 		req,
 		"",
@@ -148,6 +152,7 @@ func TestOPATransportResponseWithError(t *testing.T) {
 }
 
 func TestOPATransportRoundTrip(t *testing.T) {
+	config := &core.RondConfig{}
 	logger, _ := test.NewNullLogger()
 	req := httptest.NewRequest(http.MethodGet, "/users", nil)
 
@@ -155,6 +160,7 @@ func TestOPATransportRoundTrip(t *testing.T) {
 		transport := NewOPATransport(
 			&MockRoundTrip{Error: fmt.Errorf("some error")},
 			req.Context(),
+			config,
 			logrus.NewEntry(logger),
 			req,
 			"",
@@ -275,6 +281,7 @@ func TestOPATransportRoundTrip(t *testing.T) {
 		transport := NewOPATransport(
 			&MockRoundTrip{Response: resp},
 			req.Context(),
+			config,
 			logrus.NewEntry(logger),
 			req,
 			"",


### PR DESCRIPTION
This PR partially address #273; in the issue the proposal is to be able to decide on multiple levels when the body should not be read (request/response/all).

Working on the request side (which addresses our main issue) was easy, while working on the response is not immediately obvious, the problem there has two faces:

 * there's still some tech debt on owns the responsibility to read the body
 * the response flow is mostly meant to interact with the body, changing the underlying behaviour without proper considerations could make the feature useless

Having dealt with only the request flow I avoided working on the configuration at the general options level.