### PR TITLE
feat: mongodb maxIdleTimeMs

### DIFF
--- a/custom_builtins/mongoclient_test.go
+++ b/custom_builtins/mongoclient_test.go
@@ -32,7 +32,7 @@ func TestNewMongoClient(t *testing.T) {
 	log := logging.NewNoOpLogger()
 
 	mongoDBURL, _ := getMongoDBURL(t)
-	mongoClient, err := mongoclient.NewMongoClient(log, mongoDBURL)
+	mongoClient, err := mongoclient.NewMongoClient(log, mongoDBURL, mongoclient.ConnectionOpts{})
 	require.NoError(t, err)
 
 	client, err := NewMongoClient(logging.NewNoOpLogger(), mongoClient)
@@ -67,7 +67,7 @@ func TestGetMongoCollectionFromContext(t *testing.T) {
 func TestMongoFindOne(t *testing.T) {
 	log := logging.NewNoOpLogger()
 	mongoDBURL, dbName := getMongoDBURL(t)
-	client, err := mongoclient.NewMongoClient(log, mongoDBURL)
+	client, err := mongoclient.NewMongoClient(log, mongoDBURL, mongoclient.ConnectionOpts{})
 	require.NoError(t, err)
 	defer client.Disconnect()
 
@@ -109,7 +109,7 @@ func TestMongoFindOne(t *testing.T) {
 func TestMongoFindMany(t *testing.T) {
 	log := logging.NewNoOpLogger()
 	mongoDBURL, dbName := getMongoDBURL(t)
-	client, err := mongoclient.NewMongoClient(log, mongoDBURL)
+	client, err := mongoclient.NewMongoClient(log, mongoDBURL, mongoclient.ConnectionOpts{})
 	require.NoError(t, err)
 	defer client.Disconnect()
 

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -37,26 +37,27 @@ const (
 // EnvironmentVariables struct with the mapping of desired
 // environment variables.
 type EnvironmentVariables struct {
-	LogLevel                 string
-	HTTPPort                 string
-	ServiceVersion           string
-	TargetServiceHost        string
-	TargetServiceOASPath     string
-	OPAModulesDirectory      string
-	APIPermissionsFilePath   string
-	UserPropertiesHeader     string
-	UserGroupsHeader         string
-	UserIdHeader             string
-	ClientTypeHeader         string
-	BindingsCrudServiceURL   string
-	MongoDBUrl               string
-	RolesCollectionName      string
-	BindingsCollectionName   string
-	PathPrefixStandalone     string
-	DelayShutdownSeconds     int
-	Standalone               bool
-	AdditionalHeadersToProxy string
-	ExposeMetrics            bool
+	LogLevel                       string
+	HTTPPort                       string
+	ServiceVersion                 string
+	TargetServiceHost              string
+	TargetServiceOASPath           string
+	OPAModulesDirectory            string
+	APIPermissionsFilePath         string
+	UserPropertiesHeader           string
+	UserGroupsHeader               string
+	UserIdHeader                   string
+	ClientTypeHeader               string
+	BindingsCrudServiceURL         string
+	MongoDBUrl                     string
+	MongoDBConnectionMaxIdleTimeMs int
+	RolesCollectionName            string
+	BindingsCollectionName         string
+	PathPrefixStandalone           string
+	DelayShutdownSeconds           int
+	Standalone                     bool
+	AdditionalHeadersToProxy       string
+	ExposeMetrics                  bool
 }
 
 var EnvVariablesConfig = []configlib.EnvConfig{
@@ -120,6 +121,11 @@ var EnvVariablesConfig = []configlib.EnvConfig{
 	{
 		Key:      "MONGODB_URL",
 		Variable: "MongoDBUrl",
+	},
+	{
+		Key:          "MONGODB_CONNECTION_MAX_IDLE_TIME_MS",
+		Variable:     "MongoDBConnectionMaxIdleTimeMs",
+		DefaultValue: "1000",
 	},
 	{
 		Key:      "BINDINGS_COLLECTION_NAME",

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -78,10 +78,11 @@ func TestGetEnvOrDie(t *testing.T) {
 		PathPrefixStandalone: "/eval",
 		ServiceVersion:       "latest",
 
-		OPAModulesDirectory:      "/modules",
-		APIPermissionsFilePath:   "/oas",
-		AdditionalHeadersToProxy: "miauserid",
-		ExposeMetrics:            true,
+		OPAModulesDirectory:            "/modules",
+		APIPermissionsFilePath:         "/oas",
+		AdditionalHeadersToProxy:       "miauserid",
+		ExposeMetrics:                  true,
+		MongoDBConnectionMaxIdleTimeMs: 1000,
 	}
 
 	t.Run(`returns correctly - with TargetServiceHost`, func(t *testing.T) {

--- a/internal/mongoclient/mongoclient.go
+++ b/internal/mongoclient/mongoclient.go
@@ -35,9 +35,13 @@ type MongoClient struct {
 const STATE string = "__STATE__"
 const PUBLIC string = "PUBLIC"
 
+type ConnectionOpts struct {
+	MaxIdleTimeMs int
+}
+
 // NewMongoClient tries to setup a new MongoClient instance.
 // The function returns a `nil` client if the environment variable `MongoDBUrl` is not specified.
-func NewMongoClient(logger logging.Logger, mongodbURL string) (*MongoClient, error) {
+func NewMongoClient(logger logging.Logger, mongodbURL string, connectionOptions ConnectionOpts) (*MongoClient, error) {
 	if mongodbURL == "" {
 		logger.Info("No MongoDB configuration provided, skipping setup")
 		return nil, nil
@@ -50,7 +54,13 @@ func NewMongoClient(logger logging.Logger, mongodbURL string) (*MongoClient, err
 		return nil, fmt.Errorf("failed MongoDB connection string validation: %s", err.Error())
 	}
 
-	clientOpts := options.Client().ApplyURI(mongodbURL)
+	clientOpts := options.Client().
+		ApplyURI(mongodbURL)
+
+	if connectionOptions.MaxIdleTimeMs != 0 {
+		clientOpts = clientOpts.SetMaxConnIdleTime(time.Duration(connectionOptions.MaxIdleTimeMs) * time.Millisecond)
+	}
+
 	client, err := mongo.Connect(context.Background(), clientOpts)
 	if err != nil {
 		return nil, fmt.Errorf("error connecting to MongoDB: %s", err.Error())

--- a/internal/mongoclient/mongoclient.go
+++ b/internal/mongoclient/mongoclient.go
@@ -54,9 +54,7 @@ func NewMongoClient(logger logging.Logger, mongodbURL string, connectionOptions 
 		return nil, fmt.Errorf("failed MongoDB connection string validation: %s", err.Error())
 	}
 
-	clientOpts := options.Client().
-		ApplyURI(mongodbURL)
-
+	clientOpts := options.Client().ApplyURI(mongodbURL)
 	if connectionOptions.MaxIdleTimeMs != 0 {
 		clientOpts = clientOpts.SetMaxConnIdleTime(time.Duration(connectionOptions.MaxIdleTimeMs) * time.Millisecond)
 	}

--- a/internal/mongoclient/mongoclient_test.go
+++ b/internal/mongoclient/mongoclient_test.go
@@ -67,7 +67,9 @@ func TestSetupMongoCollection(t *testing.T) {
 		}
 
 		log := logging.NewNoOpLogger()
-		mongoClient, err := NewMongoClient(log, fmt.Sprintf("mongodb://%s/%s", mongoHost, testutils.GetRandomName(10)), connOptions)
+		mongoClient, err := NewMongoClient(log, fmt.Sprintf("mongodb://%s/%s", mongoHost, testutils.GetRandomName(10)), ConnectionOpts{
+			MaxIdleTimeMs: 2000,
+		})
 
 		collName := "a-collection"
 		coll := mongoClient.Collection(collName)

--- a/internal/mongoclient/mongoclient_test.go
+++ b/internal/mongoclient/mongoclient_test.go
@@ -26,9 +26,11 @@ import (
 )
 
 func TestSetupMongoCollection(t *testing.T) {
+	connOptions := ConnectionOpts{}
+
 	t.Run("if MongoDBUrl empty, returns nil", func(t *testing.T) {
 		log := logging.NewNoOpLogger()
-		adapter, _ := NewMongoClient(log, "")
+		adapter, _ := NewMongoClient(log, "", connOptions)
 		require.True(t, adapter == nil, "MongoDBUrl is not nil")
 	})
 
@@ -36,7 +38,7 @@ func TestSetupMongoCollection(t *testing.T) {
 		mongoHost := "not-valid-mongo-url"
 
 		log := logging.NewNoOpLogger()
-		adapter, err := NewMongoClient(log, mongoHost)
+		adapter, err := NewMongoClient(log, mongoHost, connOptions)
 		require.True(t, err != nil, "setup mongo not returns error")
 		require.Contains(t, err.Error(), "failed MongoDB connection string validation:")
 		require.True(t, adapter == nil)
@@ -50,7 +52,7 @@ func TestSetupMongoCollection(t *testing.T) {
 		}
 
 		log := logging.NewNoOpLogger()
-		mongoClient, err := NewMongoClient(log, fmt.Sprintf("mongodb://%s/%s", mongoHost, testutils.GetRandomName(10)))
+		mongoClient, err := NewMongoClient(log, fmt.Sprintf("mongodb://%s/%s", mongoHost, testutils.GetRandomName(10)), connOptions)
 
 		defer mongoClient.Disconnect()
 		require.True(t, err == nil, "setup mongo returns error")
@@ -65,7 +67,7 @@ func TestSetupMongoCollection(t *testing.T) {
 		}
 
 		log := logging.NewNoOpLogger()
-		mongoClient, err := NewMongoClient(log, fmt.Sprintf("mongodb://%s/%s", mongoHost, testutils.GetRandomName(10)))
+		mongoClient, err := NewMongoClient(log, fmt.Sprintf("mongodb://%s/%s", mongoHost, testutils.GetRandomName(10)), connOptions)
 
 		collName := "a-collection"
 		coll := mongoClient.Collection(collName)

--- a/main.go
+++ b/main.go
@@ -97,7 +97,9 @@ func entrypoint(shutdown chan os.Signal) {
 
 	var mongoDriver *mongoclient.MongoClient
 	if env.MongoDBUrl != "" {
-		client, err := mongoclient.NewMongoClient(rondLogger, env.MongoDBUrl)
+		client, err := mongoclient.NewMongoClient(rondLogger, env.MongoDBUrl, mongoclient.ConnectionOpts{
+			MaxIdleTimeMs: 0, // TODO
+		})
 		if err != nil {
 			log.WithFields(logrus.Fields{
 				"error": logrus.Fields{"message": err.Error()},

--- a/main.go
+++ b/main.go
@@ -98,7 +98,7 @@ func entrypoint(shutdown chan os.Signal) {
 	var mongoDriver *mongoclient.MongoClient
 	if env.MongoDBUrl != "" {
 		client, err := mongoclient.NewMongoClient(rondLogger, env.MongoDBUrl, mongoclient.ConnectionOpts{
-			MaxIdleTimeMs: 0, // TODO
+			MaxIdleTimeMs: env.MongoDBConnectionMaxIdleTimeMs,
 		})
 		if err != nil {
 			log.WithFields(logrus.Fields{

--- a/sdk/inputuser/mongo/mongoclient_test.go
+++ b/sdk/inputuser/mongo/mongoclient_test.go
@@ -35,7 +35,7 @@ func TestSetupMongoCollection(t *testing.T) {
 
 	t.Run("if RolesCollectionName empty, returns error", func(t *testing.T) {
 		mongoDBURL, _, _, _ := getMongoDBURL(t)
-		client, err := mongoclient.NewMongoClient(log, mongoDBURL)
+		client, err := mongoclient.NewMongoClient(log, mongoDBURL, mongoclient.ConnectionOpts{})
 		require.NoError(t, err)
 
 		config := Config{
@@ -49,7 +49,7 @@ func TestSetupMongoCollection(t *testing.T) {
 
 	t.Run("correctly returns mongodb client", func(t *testing.T) {
 		mongoDBURL, _, _, _ := getMongoDBURL(t)
-		client, err := mongoclient.NewMongoClient(log, mongoDBURL)
+		client, err := mongoclient.NewMongoClient(log, mongoDBURL, mongoclient.ConnectionOpts{})
 		require.NoError(t, err)
 
 		config := Config{
@@ -70,7 +70,7 @@ func TestMongoCollections(t *testing.T) {
 
 	t.Run("testing retrieve user bindings from mongo", func(t *testing.T) {
 		mongoDBURL, _, rolesCollection, bindingsCollection := getMongoDBURL(t)
-		client, err := mongoclient.NewMongoClient(log, mongoDBURL)
+		client, err := mongoclient.NewMongoClient(log, mongoDBURL, mongoclient.ConnectionOpts{})
 		require.NoError(t, err)
 
 		config := Config{
@@ -151,7 +151,7 @@ func TestMongoCollections(t *testing.T) {
 
 	t.Run("testing retrieve user bindings from mongo - user without groups", func(t *testing.T) {
 		mongoDBURL, _, rolesCollection, bindingsCollection := getMongoDBURL(t)
-		client, err := mongoclient.NewMongoClient(log, mongoDBURL)
+		client, err := mongoclient.NewMongoClient(log, mongoDBURL, mongoclient.ConnectionOpts{})
 		require.NoError(t, err)
 
 		config := Config{
@@ -200,7 +200,7 @@ func TestMongoCollections(t *testing.T) {
 
 	t.Run("testing retrieve user bindings from mongo - no userId passed", func(t *testing.T) {
 		mongoDBURL, _, rolesCollection, bindingsCollection := getMongoDBURL(t)
-		client, err := mongoclient.NewMongoClient(log, mongoDBURL)
+		client, err := mongoclient.NewMongoClient(log, mongoDBURL, mongoclient.ConnectionOpts{})
 		require.NoError(t, err)
 		config := Config{
 			RolesCollectionName:    "roles",
@@ -230,7 +230,7 @@ func TestMongoCollections(t *testing.T) {
 		_, dbName, rolesCollection, bindingsCollection := testutils.GetAndDisposeTestClientsAndCollections(t)
 		mongoDBURL := fmt.Sprintf("mongodb://%s/%s", mongoHost, dbName)
 
-		client, err := mongoclient.NewMongoClient(log, mongoDBURL)
+		client, err := mongoclient.NewMongoClient(log, mongoDBURL, mongoclient.ConnectionOpts{})
 		require.NoError(t, err)
 
 		config := Config{


### PR DESCRIPTION
Added env var to control the MongoDB `maxIdleTimeMs` connection property

I decided to have a default value set to 1s to the var, we may consider further tuning in future patches if the value seems to aggressive. After some local benchmark I didn't found particular issues but my M2 processor is far too powerful compared to the general purpose GCP CPUs 😅 