### PR TITLE
fix: prevent exposing interface using an internal package

### DIFF
--- a/custom_builtins/mongoclient.go
+++ b/custom_builtins/mongoclient.go
@@ -20,8 +20,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/rond-authz/rond/internal/mongoclient"
 	"github.com/rond-authz/rond/logging"
+	"github.com/rond-authz/rond/types"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -52,13 +52,11 @@ func GetMongoClientFromContext(ctx context.Context) (IMongoClient, error) {
 }
 
 type MongoClient struct {
-	client *mongoclient.MongoClient
+	client types.MongoClient
 }
 
-func NewMongoClient(logger logging.Logger, mongoClient *mongoclient.MongoClient) (IMongoClient, error) {
-	return &MongoClient{
-		client: mongoClient,
-	}, nil
+func NewMongoClient(logger logging.Logger, mongoClient types.MongoClient) (IMongoClient, error) {
+	return &MongoClient{client: mongoClient}, nil
 }
 
 func (mongoClient *MongoClient) FindOne(ctx context.Context, collectionName string, query map[string]interface{}) (interface{}, error) {

--- a/sdk/inputuser/mongo/mongoclient.go
+++ b/sdk/inputuser/mongo/mongoclient.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/rond-authz/rond/internal/mongoclient"
 	"github.com/rond-authz/rond/logging"
 	"github.com/rond-authz/rond/sdk/inputuser"
 	"github.com/rond-authz/rond/types"
@@ -28,7 +27,7 @@ import (
 )
 
 type MongoClient struct {
-	*mongoclient.MongoClient
+	types.MongoClient
 	bindings *mongo.Collection
 	roles    *mongo.Collection
 }
@@ -42,7 +41,7 @@ type Config struct {
 }
 
 // NewMongoClient creates the struct for accessing user bindings
-func NewMongoClient(logger logging.Logger, client *mongoclient.MongoClient, config Config) (inputuser.Client, error) {
+func NewMongoClient(logger logging.Logger, client types.MongoClient, config Config) (inputuser.Client, error) {
 	if config.RolesCollectionName == "" || config.BindingsCollectionName == "" {
 		return nil, fmt.Errorf(
 			`MongoDB url is not empty, required variables might be missing: BindingsCollectionName: "%s",  RolesCollectionName: "%s"`,

--- a/types/rbactypes.go
+++ b/types/rbactypes.go
@@ -15,6 +15,8 @@
 // TODO: check if types should be removed from here, and set in correct packages
 package types
 
+import "go.mongodb.org/mongo-driver/mongo"
+
 type Resource struct {
 	ResourceType string `bson:"resourceType" json:"resourceType,omitempty"`
 	ResourceID   string `bson:"resourceId" json:"resourceId,omitempty"`
@@ -56,4 +58,9 @@ type User struct {
 	ID         string
 	Groups     []string
 	Properties map[string]any
+}
+
+type MongoClient interface {
+	Collection(collectionName string) *mongo.Collection
+	Disconnect() error
 }


### PR DESCRIPTION
This PR fixes an issue with v1.12.0+ that exposes the NewMongoClient method (from `custom_builtins` and `mongoinputuser` packages) that uses the `internal/mongoclient` struct definition.

I've created a new interface (another one, gasp) that abstracts both clients. I've put it in the `types` package since is currently the only place that is shared among all the packages.