### PR TITLE
fix: unstable ci due to coveralls race

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,8 @@ jobs:
         uses: shogo82148/actions-goveralls@v1
         with:
           path-to-profile: coverage.out
-
+          flag-name: Go-${{ matrix.go_version }}
+          parallel: true
   test-latest:
     name: Test latest
     strategy:


### PR DESCRIPTION
Lot's of ci actions are failing due to a race with coveralls

```
/home/runner/work/_actions/shogo82148/actions-goveralls/v1/bin/goveralls_linux_amd64 -service=github -coverprofile=coverage.out
bad response status from coveralls: 422
{"message":"Can't add a job to a build that is already closed. Build 7255384918 is closed. See docs.coveralls.io/parallel-builds","error":true}
Error: Error: The process '/home/runner/work/_actions/shogo82148/actions-goveralls/v1/bin/goveralls_linux_amd64' failed with exit code 1
```


This pr should fix