### PR TITLE
perf: prepare partial evaluation at boot for better performances

### DIFF
--- a/core/input_test.go
+++ b/core/input_test.go
@@ -30,7 +30,7 @@ func TestCreateRegoInput(t *testing.T) {
 	t.Run("returns correctly", func(t *testing.T) {
 		actual, err := CreateRegoQueryInput(log, Input{}, RegoInputOptions{})
 		require.NoError(t, err)
-		require.Equal(t, "{\"request\":{\"method\":\"\",\"path\":\"\"},\"response\":{},\"user\":{}}", string(actual))
+		require.Equal(t, "{\"request\":{\"method\":\"\",\"path\":\"\"},\"response\":{},\"user\":{}}", string(actual.Location.Text))
 	})
 
 	t.Run("buildOptimizedResourcePermissionsMap", func(t *testing.T) {

--- a/core/opaevaluator.go
+++ b/core/opaevaluator.go
@@ -82,6 +82,10 @@ func (opaEval *OPAEvaluator) partiallyEvaluate(logger logging.Logger, input Eval
 	}
 	opaEvaluationTimeStart := time.Now()
 
+	if opaEval.evaluator.preparedPartialQuery == nil {
+		return nil, fmt.Errorf("%w: %s", ErrPartialPolicyEvalFailed, "preparedPartialQuery is nil")
+	}
+
 	partialResults, err := opaEval.evaluator.preparedPartialQuery.Partial(
 		opaEval.getContext(),
 		rego.EvalParsedInput(input.Value),
@@ -124,6 +128,9 @@ func (opaEval *OPAEvaluator) partiallyEvaluate(logger logging.Logger, input Eval
 func (opaEval *OPAEvaluator) Evaluate(logger logging.Logger, input EvalInput, options *PolicyEvaluationOptions) (interface{}, error) {
 	if options == nil {
 		options = &PolicyEvaluationOptions{}
+	}
+	if opaEval.evaluator.preparedEvalQuery == nil {
+		return nil, fmt.Errorf("%w: %s", ErrPolicyEvalFailed, "preparedEvalQuery is nil")
 	}
 
 	opaEvaluationTimeStart := time.Now()

--- a/core/opaevaluator.go
+++ b/core/opaevaluator.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/rond-authz/rond/custom_builtins"
@@ -62,19 +61,20 @@ type PermissionOptions struct {
 
 type Evaluator interface {
 	Eval(ctx context.Context) (rego.ResultSet, error)
-	Partial(ctx context.Context) (*rego.PartialQueries, error)
 }
 
 var Unknowns = []string{"data.resources"}
 
 type OPAEvaluator struct {
-	PolicyEvaluator Evaluator
-	PolicyName      string
+	policyEvaluator      Evaluator
+	preparedPartialQuery *rego.PreparedPartialQuery
+	PolicyName           string
 
 	context       context.Context
 	mongoClient   custom_builtins.IMongoClient
 	generateQuery bool
 	logger        logging.Logger
+	input         []byte
 }
 
 type OPAEvaluatorOptions struct {
@@ -83,64 +83,17 @@ type OPAEvaluatorOptions struct {
 	Logger                logging.Logger
 }
 
-func newQueryOPAEvaluator(ctx context.Context, policy string, opaModuleConfig *OPAModuleConfig, input []byte, options *OPAEvaluatorOptions) (*OPAEvaluator, error) {
-	if options == nil {
-		options = &OPAEvaluatorOptions{}
-	}
-	inputTerm, err := ast.ParseTerm(string(input))
-	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrFailedInputParse, err)
-	}
-
-	sanitizedPolicy := strings.Replace(policy, ".", "_", -1)
-	queryString := fmt.Sprintf("data.policies.%s", sanitizedPolicy)
-	query := rego.New(
-		rego.Query(queryString),
-		rego.Module(opaModuleConfig.Name, opaModuleConfig.Content),
-		rego.ParsedInput(inputTerm.Value),
-		rego.Unknowns(Unknowns),
-		rego.Capabilities(ast.CapabilitiesForThisVersion()),
-		rego.EnablePrintStatements(options.EnablePrintStatements),
-		rego.PrintHook(NewPrintHook(os.Stdout, policy)),
-		custom_builtins.GetHeaderFunction,
-		custom_builtins.MongoFindOne,
-		custom_builtins.MongoFindMany,
-	)
-
-	return &OPAEvaluator{
-		PolicyEvaluator: query,
-		PolicyName:      policy,
-
-		context:       ctx,
-		mongoClient:   options.MongoClient,
-		generateQuery: true,
-		logger:        options.Logger,
-	}, nil
-}
-
-func (config *OPAModuleConfig) CreateQueryEvaluator(ctx context.Context, logger logging.Logger, policy string, input []byte, options *OPAEvaluatorOptions) (*OPAEvaluator, error) {
-	logger.WithFields(map[string]any{
-		"policyName": policy,
-	}).Info("Policy to be evaluated")
-
-	opaEvaluatorInstanceTime := time.Now()
-	evaluator, err := newQueryOPAEvaluator(ctx, policy, config, input, options)
-	if err != nil {
-		logger.WithField("error", err).Error(ErrEvaluatorCreationFailed)
-		return nil, err
-	}
-	logger.
-		WithField("evaluatorCreationTimeMicroseconds", time.Since(opaEvaluatorInstanceTime).Microseconds()).
-		Trace("evaluator creation time")
-	return evaluator, nil
-}
-
 func (evaluator *OPAEvaluator) partiallyEvaluate(logger logging.Logger, options *PolicyEvaluationOptions) (primitive.M, error) {
 	if options == nil {
 		options = &PolicyEvaluationOptions{}
 	}
 	opaEvaluationTimeStart := time.Now()
-	partialResults, err := evaluator.PolicyEvaluator.Partial(evaluator.getContext())
+	inputTerm, err := ast.ParseTerm(string(evaluator.input))
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrFailedInputParse, err)
+	}
+
+	partialResults, err := evaluator.preparedPartialQuery.Partial(evaluator.getContext(), rego.EvalParsedInput(inputTerm.Value))
 	if err != nil {
 		return nil, fmt.Errorf("%w: %s", ErrPartialPolicyEvalFailed, err.Error())
 	}
@@ -182,7 +135,7 @@ func (evaluator *OPAEvaluator) Evaluate(logger logging.Logger, options *PolicyEv
 
 	opaEvaluationTimeStart := time.Now()
 
-	results, err := evaluator.PolicyEvaluator.Eval(evaluator.getContext())
+	results, err := evaluator.policyEvaluator.Eval(evaluator.getContext())
 	if err != nil {
 		return nil, fmt.Errorf("%w: %s", ErrPolicyEvalFailed, err.Error())
 	}

--- a/core/opaevaluator_test.go
+++ b/core/opaevaluator_test.go
@@ -82,6 +82,30 @@ func TestOPAEvaluator(t *testing.T) {
 			require.Equal(t, log, actualLog)
 		})
 	})
+
+	t.Run("PolicyEvaluation", func(t *testing.T) {
+		t.Run("with empty evaluator - generate query", func(t *testing.T) {
+			opaEval := OPAEvaluator{
+				generateQuery: true,
+			}
+			logger := logging.NewNoOpLogger()
+			result, query, err := opaEval.PolicyEvaluation(logger, nil, nil)
+
+			require.EqualError(t, err, "partial policy evaluation failed: preparedPartialQuery is nil")
+			require.Nil(t, result)
+			require.Empty(t, query)
+		})
+
+		t.Run("with empty evaluator - eval query", func(t *testing.T) {
+			opaEval := OPAEvaluator{}
+			logger := logging.NewNoOpLogger()
+			result, query, err := opaEval.PolicyEvaluation(logger, nil, nil)
+
+			require.EqualError(t, err, "policy evaluation failed: preparedEvalQuery is nil")
+			require.Nil(t, result)
+			require.Empty(t, query)
+		})
+	})
 }
 
 func TestBuildRolesMap(t *testing.T) {

--- a/core/opaevaluator_test.go
+++ b/core/opaevaluator_test.go
@@ -26,22 +26,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// func TestNewOPAEvaluator(t *testing.T) {
-// 	input := map[string]interface{}{}
-// 	inputBytes, _ := json.Marshal(input)
-// 	t.Run("policy sanitization", func(t *testing.T) {
-// 		evaluator, _ := newQueryOPAEvaluator(context.Background(), "very.composed.policy", &OPAModuleConfig{Content: "package policies very_composed_policy {true}"}, inputBytes, nil)
-
-// 		result, err := evaluator.policyEvaluator.Eval(context.TODO())
-// 		require.Nil(t, err, "unexpected error")
-// 		require.True(t, result.Allowed(), "Unexpected failing policy")
-
-// 		parialResult, err := evaluator.policyEvaluator.Partial(context.TODO())
-// 		require.Nil(t, err, "unexpected error")
-// 		require.Equal(t, 1, len(parialResult.Queries), "Unexpected failing policy")
-// 	})
-// }
-
 func TestOPAEvaluator(t *testing.T) {
 	t.Run("get context", func(t *testing.T) {
 		t.Run("no context", func(t *testing.T) {
@@ -118,55 +102,3 @@ func TestBuildRolesMap(t *testing.T) {
 	}
 	require.Equal(t, expected, result)
 }
-
-// func TestGetHeaderFunction(t *testing.T) {
-// 	headerKeyMocked := "exampleKey"
-// 	headerValueMocked := "value"
-
-// 	opaModule := &OPAModuleConfig{
-// 		Name: "example.rego",
-// 		Content: `package policies
-// 		todo { get_header("ExAmPlEkEy", input.headers) == "value" }`,
-// 	}
-// 	queryString := "todo"
-
-// 	t.Run("if header key exists", func(t *testing.T) {
-// 		headers := http.Header{}
-// 		headers.Add(headerKeyMocked, headerValueMocked)
-// 		input := map[string]interface{}{
-// 			"headers": headers,
-// 		}
-// 		inputBytes, _ := json.Marshal(input)
-
-// 		opaEvaluator, err := newQueryOPAEvaluator(context.Background(), queryString, opaModule, inputBytes, nil)
-// 		require.NoError(t, err, "Unexpected error during creation of opaEvaluator")
-
-// 		results, err := opaEvaluator.policyEvaluator.Eval(context.TODO())
-// 		require.NoError(t, err, "Unexpected error during rego validation")
-// 		require.True(t, results.Allowed(), "The input is not allowed by rego")
-
-// 		partialResults, err := opaEvaluator.policyEvaluator.Partial(context.TODO())
-// 		require.NoError(t, err, "Unexpected error during rego validation")
-
-// 		require.Len(t, partialResults.Queries, 1, "Rego policy allows illegal input")
-// 	})
-
-// 	t.Run("if header key not exists", func(t *testing.T) {
-// 		input := map[string]interface{}{
-// 			"headers": http.Header{},
-// 		}
-// 		inputBytes, _ := json.Marshal(input)
-
-// 		opaEvaluator, err := newQueryOPAEvaluator(context.Background(), queryString, opaModule, inputBytes, nil)
-// 		require.NoError(t, err, "Unexpected error during creation of opaEvaluator")
-
-// 		results, err := opaEvaluator.policyEvaluator.Eval(context.TODO())
-// 		require.NoError(t, err, "Unexpected error during rego validation")
-// 		require.True(t, !results.Allowed(), "Rego policy allows illegal input")
-
-// 		partialResults, err := opaEvaluator.policyEvaluator.Partial(context.TODO())
-// 		require.NoError(t, err, "Unexpected error during rego validation")
-
-// 		require.Len(t, partialResults.Queries, 0, "Rego policy allows illegal input")
-// 	})
-// }

--- a/core/partialevaluators.go
+++ b/core/partialevaluators.go
@@ -48,7 +48,7 @@ func (policyEvaluators PartialResultsEvaluators) AddFromConfig(ctx context.Conte
 	}
 
 	if _, ok := policyEvaluators[allowPolicy]; !ok {
-		evaluator, err := createPartialEvaluator(logger, allowPolicy, opaModuleConfig, options, isFilterQuery)
+		evaluator, err := createPartialEvaluator(ctx, logger, allowPolicy, opaModuleConfig, options, isFilterQuery)
 		if err != nil {
 			return fmt.Errorf("%w: %s", ErrEvaluatorCreationFailed, err.Error())
 		}
@@ -57,7 +57,7 @@ func (policyEvaluators PartialResultsEvaluators) AddFromConfig(ctx context.Conte
 
 	if responsePolicy != "" {
 		if _, ok := policyEvaluators[responsePolicy]; !ok {
-			evaluator, err := createPartialEvaluator(logger, responsePolicy, opaModuleConfig, options, false)
+			evaluator, err := createPartialEvaluator(ctx, logger, responsePolicy, opaModuleConfig, options, false)
 			if err != nil {
 				return fmt.Errorf("%w: %s", ErrEvaluatorCreationFailed, err.Error())
 			}
@@ -87,7 +87,7 @@ func (partialEvaluators PartialResultsEvaluators) GetEvaluatorFromPolicy(ctx con
 	return nil, fmt.Errorf("%w: %s", ErrEvaluatorNotFound, policy)
 }
 
-func createPartialEvaluator(logger logging.Logger, policy string, opaModuleConfig *OPAModuleConfig, options *OPAEvaluatorOptions, isPartial bool) (*PartialEvaluator, error) {
+func createPartialEvaluator(ctx context.Context, logger logging.Logger, policy string, opaModuleConfig *OPAModuleConfig, options *OPAEvaluatorOptions, isPartial bool) (*PartialEvaluator, error) {
 	logger.WithField("policyName", policy).Info("precomputing rego policy")
 
 	preparedPartialEvaluator := &PartialEvaluator{}
@@ -99,13 +99,13 @@ func createPartialEvaluator(logger logging.Logger, policy string, opaModuleConfi
 		return nil, err
 	}
 	if isPartial {
-		preparedPartialQuery, err := regoInstance.PrepareForPartial(context.TODO())
+		preparedPartialQuery, err := regoInstance.PrepareForPartial(ctx)
 		if err != nil {
 			return nil, err
 		}
 		preparedPartialEvaluator.preparedPartialQuery = &preparedPartialQuery
 	} else {
-		partialResultEvaluator, err := regoInstance.PrepareForEval(context.TODO())
+		partialResultEvaluator, err := regoInstance.PrepareForEval(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/core/partialevaluators_test.go
+++ b/core/partialevaluators_test.go
@@ -95,9 +95,9 @@ func TestPartialResultEvaluators(t *testing.T) {
 		t.Run("find and evaluate policy - request", func(t *testing.T) {
 			input, err := CreateRegoQueryInput(logger, rondInput, RegoInputOptions{})
 			require.NoError(t, err)
-			evaluator, err := partialEvaluators.GetEvaluatorFromPolicy(ctx, "allow", input, nil)
+			evaluator, err := partialEvaluators.GetEvaluatorFromPolicy(ctx, "allow", nil)
 			require.NoError(t, err)
-			res, err := evaluator.Evaluate(logger, nil)
+			res, err := evaluator.Evaluate(logger, input, nil)
 			require.NoError(t, err)
 			require.Nil(t, res)
 		})
@@ -105,9 +105,9 @@ func TestPartialResultEvaluators(t *testing.T) {
 		t.Run("find and evaluate policy - response fails", func(t *testing.T) {
 			input, err := CreateRegoQueryInput(logger, rondInput, RegoInputOptions{})
 			require.NoError(t, err)
-			evaluator, err := partialEvaluators.GetEvaluatorFromPolicy(ctx, "column_policy", input, nil)
+			evaluator, err := partialEvaluators.GetEvaluatorFromPolicy(ctx, "column_policy", nil)
 			require.NoError(t, err)
-			_, err = evaluator.Evaluate(logger, nil)
+			_, err = evaluator.Evaluate(logger, input, nil)
 			require.EqualError(t, err, ErrPolicyNotAllowed.Error())
 		})
 	})
@@ -153,9 +153,9 @@ func TestPartialResultEvaluators(t *testing.T) {
 		t.Run("find and evaluate policy", func(t *testing.T) {
 			input, err := CreateRegoQueryInput(logger, rondInput, RegoInputOptions{})
 			require.NoError(t, err)
-			evaluator, err := partialEvaluators.GetEvaluatorFromPolicy(context.Background(), "allow_with_find_one", input, &evalOpts)
+			evaluator, err := partialEvaluators.GetEvaluatorFromPolicy(context.Background(), "allow_with_find_one", &evalOpts)
 			require.NoError(t, err)
-			res, query, err := evaluator.PolicyEvaluation(logger, nil)
+			res, query, err := evaluator.PolicyEvaluation(logger, input, nil)
 			require.NoError(t, err)
 			require.Empty(t, query)
 			require.Empty(t, res)
@@ -192,9 +192,9 @@ func TestPartialResultEvaluators(t *testing.T) {
 		t.Run("find and evaluate policy", func(t *testing.T) {
 			input, err := CreateRegoQueryInput(logger, rondInput, RegoInputOptions{})
 			require.NoError(t, err)
-			evaluator, err := partialEvaluators.GetEvaluatorFromPolicy(context.Background(), "allow", input, &evalOpts)
+			evaluator, err := partialEvaluators.GetEvaluatorFromPolicy(context.Background(), "allow", &evalOpts)
 			require.NoError(t, err)
-			res, query, err := evaluator.PolicyEvaluation(logger, nil)
+			res, query, err := evaluator.PolicyEvaluation(logger, input, nil)
 			require.NoError(t, err)
 			require.Empty(t, query)
 			require.Empty(t, res)
@@ -256,9 +256,9 @@ func TestPartialResultEvaluators(t *testing.T) {
 		t.Run("find and evaluate policy", func(t *testing.T) {
 			input, err := CreateRegoQueryInput(logger, rondInput, RegoInputOptions{})
 			require.NoError(t, err)
-			evaluator, err := partialEvaluators.GetEvaluatorFromPolicy(context.Background(), "filter_projects", input, &evalOpts)
+			evaluator, err := partialEvaluators.GetEvaluatorFromPolicy(context.Background(), "filter_projects", &evalOpts)
 			require.NoError(t, err)
-			res, query, err := evaluator.PolicyEvaluation(logger, nil)
+			res, query, err := evaluator.PolicyEvaluation(logger, input, nil)
 			require.NoError(t, err)
 			require.Empty(t, res)
 
@@ -323,12 +323,12 @@ func TestPartialResultEvaluators(t *testing.T) {
 		t.Run("find and evaluate policy", func(t *testing.T) {
 			input, err := CreateRegoQueryInput(logger, rondInput, RegoInputOptions{})
 			require.NoError(t, err)
-			evaluator, err := partialEvaluators.GetEvaluatorFromPolicy(context.Background(), "filter_projects", input, &evalOpts)
+			evaluator, err := partialEvaluators.GetEvaluatorFromPolicy(context.Background(), "filter_projects", &evalOpts)
 			require.NoError(t, err)
 			opts := PolicyEvaluationOptions{
 				Metrics: metrics.NoOpMetrics(),
 			}
-			res, query, err := evaluator.PolicyEvaluation(logger, &opts)
+			res, query, err := evaluator.PolicyEvaluation(logger, input, &opts)
 			require.NoError(t, err)
 			require.Empty(t, res)
 
@@ -352,9 +352,9 @@ func TestPartialResultEvaluators(t *testing.T) {
 		t.Run("find and evaluate policy - request", func(t *testing.T) {
 			input, err := CreateRegoQueryInput(logger, rondInput, RegoInputOptions{})
 			require.NoError(t, err)
-			evaluator, err := partialEvaluators.GetEvaluatorFromPolicy(context.Background(), "deny", input, nil)
+			evaluator, err := partialEvaluators.GetEvaluatorFromPolicy(context.Background(), "deny", nil)
 			require.NoError(t, err)
-			_, _, err = evaluator.PolicyEvaluation(logger, nil)
+			_, _, err = evaluator.PolicyEvaluation(logger, input, nil)
 			require.EqualError(t, err, ErrPolicyNotAllowed.Error())
 		})
 	})
@@ -391,9 +391,9 @@ func TestPartialResultEvaluators(t *testing.T) {
 
 		input, err := CreateRegoQueryInput(logger, rondInput, RegoInputOptions{})
 		require.NoError(t, err)
-		evaluator, err := partialEvaluators.GetEvaluatorFromPolicy(context.Background(), "check_metadata", input, &evalOpts)
+		evaluator, err := partialEvaluators.GetEvaluatorFromPolicy(context.Background(), "check_metadata", &evalOpts)
 		require.NoError(t, err)
-		res, query, err := evaluator.PolicyEvaluation(logger, nil)
+		res, query, err := evaluator.PolicyEvaluation(logger, input, nil)
 		require.NoError(t, err)
 		require.Empty(t, query)
 		require.Empty(t, res)

--- a/core/partialevaluators_test.go
+++ b/core/partialevaluators_test.go
@@ -256,14 +256,13 @@ func TestPartialResultEvaluators(t *testing.T) {
 		t.Run("find and evaluate policy", func(t *testing.T) {
 			input, err := CreateRegoQueryInput(logger, rondInput, RegoInputOptions{})
 			require.NoError(t, err)
-			evaluator, err := opaModule.CreateQueryEvaluator(context.Background(), logger, "filter_projects", input, &evalOpts)
+			evaluator, err := partialEvaluators.GetEvaluatorFromPolicy(context.Background(), "filter_projects", input, &evalOpts)
 			require.NoError(t, err)
 			res, query, err := evaluator.PolicyEvaluation(logger, nil)
 			require.NoError(t, err)
 			require.Empty(t, res)
 
-			var actualQuery = []byte{}
-			actualQuery, err = json.Marshal(query)
+			actualQuery, err := json.Marshal(query)
 			require.NoError(t, err)
 			require.JSONEq(t, `{"$or":[{"$and":[{"filterField":{"$eq":"something"}}]}]}`, string(actualQuery))
 		})
@@ -324,7 +323,7 @@ func TestPartialResultEvaluators(t *testing.T) {
 		t.Run("find and evaluate policy", func(t *testing.T) {
 			input, err := CreateRegoQueryInput(logger, rondInput, RegoInputOptions{})
 			require.NoError(t, err)
-			evaluator, err := opaModule.CreateQueryEvaluator(context.Background(), logger, "filter_projects", input, &evalOpts)
+			evaluator, err := partialEvaluators.GetEvaluatorFromPolicy(context.Background(), "filter_projects", input, &evalOpts)
 			require.NoError(t, err)
 			opts := PolicyEvaluationOptions{
 				Metrics: metrics.NoOpMetrics(),
@@ -333,8 +332,7 @@ func TestPartialResultEvaluators(t *testing.T) {
 			require.NoError(t, err)
 			require.Empty(t, res)
 
-			var actualQuery = []byte{}
-			actualQuery, err = json.Marshal(query)
+			actualQuery, err := json.Marshal(query)
 			require.NoError(t, err)
 			require.JSONEq(t, `{"$or":[{"$and":[{"filterField":{"$eq":"something"}}]}]}`, string(actualQuery))
 		})

--- a/core/rego.go
+++ b/core/rego.go
@@ -1,0 +1,54 @@
+// Copyright 2024 Mia srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/rego"
+	"github.com/rond-authz/rond/custom_builtins"
+)
+
+func newRegoInstanceBuilder(policy string, opaModuleConfig *OPAModuleConfig, evaluatorOptions *OPAEvaluatorOptions) (*rego.Rego, error) {
+	if opaModuleConfig == nil {
+		return nil, fmt.Errorf("OPAModuleConfig must not be nil")
+	}
+
+	if evaluatorOptions == nil {
+		evaluatorOptions = &OPAEvaluatorOptions{}
+	}
+
+	sanitizedPolicy := strings.Replace(policy, ".", "_", -1)
+	queryString := fmt.Sprintf("data.policies.%s", sanitizedPolicy)
+
+	options := []func(*rego.Rego){
+		rego.Query(queryString),
+		rego.Module(opaModuleConfig.Name, opaModuleConfig.Content),
+		rego.Unknowns(Unknowns),
+		rego.EnablePrintStatements(evaluatorOptions.EnablePrintStatements),
+		rego.PrintHook(NewPrintHook(os.Stdout, policy)),
+		rego.Capabilities(ast.CapabilitiesForThisVersion()),
+		custom_builtins.GetHeaderFunction,
+	}
+	if evaluatorOptions.MongoClient != nil {
+		options = append(options, custom_builtins.MongoFindOne, custom_builtins.MongoFindMany)
+	}
+	regoInstance := rego.New(options...)
+
+	return regoInstance, nil
+}

--- a/core/rego_test.go
+++ b/core/rego_test.go
@@ -1,0 +1,98 @@
+// Copyright 2024 Mia srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/open-policy-agent/opa/rego"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewOPAEvaluator(t *testing.T) {
+	t.Run("policy sanitization", func(t *testing.T) {
+		evaluator, _ := newRegoInstanceBuilder("very.composed.policy", &OPAModuleConfig{Content: "package policies very_composed_policy {true}"}, nil)
+
+		result, err := evaluator.Eval(context.TODO())
+		require.Nil(t, err, "unexpected error")
+		require.True(t, result.Allowed(), "Unexpected failing policy")
+
+		parialResult, err := evaluator.Partial(context.TODO())
+		require.Nil(t, err, "unexpected error")
+		require.Equal(t, 1, len(parialResult.Queries), "Unexpected failing policy")
+	})
+}
+
+func TestGetHeaderFunction(t *testing.T) {
+	headerKeyMocked := "exampleKey"
+	headerValueMocked := "value"
+
+	opaModule := &OPAModuleConfig{
+		Name: "example.rego",
+		Content: `package policies
+		todo { get_header("ExAmPlEkEy", input.headers) == "value" }`,
+	}
+	queryString := "todo"
+
+	t.Run("if header key exists", func(t *testing.T) {
+		headers := http.Header{}
+		headers.Add(headerKeyMocked, headerValueMocked)
+		input := map[string]interface{}{
+			"headers": headers,
+		}
+
+		opaEvaluator, err := newRegoInstanceBuilder(queryString, opaModule, nil)
+		require.NoError(t, err, "Unexpected error during creation of opaEvaluator")
+
+		preparedEval, err := opaEvaluator.PrepareForEval(context.TODO())
+		require.NoError(t, err, "Unexpected error during rego validation")
+		preparedPartial, err := opaEvaluator.PrepareForPartial(context.TODO())
+		require.NoError(t, err, "Unexpected error during rego validation")
+
+		results, err := preparedEval.Eval(context.TODO(), rego.EvalInput(input))
+		require.NoError(t, err, "Unexpected error during rego validation")
+		require.True(t, results.Allowed(), "The input is not allowed by rego")
+
+		partialResults, err := preparedPartial.Partial(context.TODO(), rego.EvalInput(input))
+		require.NoError(t, err, "Unexpected error during rego validation")
+
+		require.Len(t, partialResults.Queries, 1, "Rego policy allows illegal input")
+	})
+
+	t.Run("if header key not exists", func(t *testing.T) {
+		input := map[string]interface{}{
+			"headers": http.Header{},
+		}
+
+		opaEvaluator, err := newRegoInstanceBuilder(queryString, opaModule, nil)
+		require.NoError(t, err, "Unexpected error during creation of opaEvaluator")
+
+		preparedEval, err := opaEvaluator.PrepareForEval(context.TODO())
+		require.NoError(t, err, "Unexpected error during rego validation")
+		preparedPartial, err := opaEvaluator.PrepareForPartial(context.TODO())
+		require.NoError(t, err, "Unexpected error during rego validation")
+
+		results, err := preparedEval.Eval(context.TODO(), rego.EvalInput(input))
+		require.NoError(t, err, "Unexpected error during rego validation")
+		require.True(t, !results.Allowed(), "Rego policy allows illegal input")
+
+		partialResults, err := preparedPartial.Partial(context.TODO(), rego.EvalInput(input))
+		require.NoError(t, err, "Unexpected error during rego validation")
+
+		require.Len(t, partialResults.Queries, 0, "Rego policy allows illegal input")
+	})
+}

--- a/sdk/evaluator.go
+++ b/sdk/evaluator.go
@@ -82,17 +82,9 @@ func (e evaluator) EvaluateRequestPolicy(ctx context.Context, rondInput core.Inp
 
 	opaEvaluatorOptions := e.evaluatorOptions.opaEvaluatorOptions(logger)
 
-	var evaluatorAllowPolicy *core.OPAEvaluator
-	if !rondConfig.RequestFlow.GenerateQuery {
-		evaluatorAllowPolicy, err = e.partialResultEvaluators.GetEvaluatorFromPolicy(ctx, rondConfig.RequestFlow.PolicyName, regoInput, opaEvaluatorOptions)
-		if err != nil {
-			return PolicyResult{}, err
-		}
-	} else {
-		evaluatorAllowPolicy, err = e.opaModuleConfig.CreateQueryEvaluator(ctx, logger, rondConfig.RequestFlow.PolicyName, regoInput, opaEvaluatorOptions)
-		if err != nil {
-			return PolicyResult{}, err
-		}
+	evaluatorAllowPolicy, err := e.partialResultEvaluators.GetEvaluatorFromPolicy(ctx, rondConfig.RequestFlow.PolicyName, regoInput, opaEvaluatorOptions)
+	if err != nil {
+		return PolicyResult{}, err
 	}
 
 	// TODO: here if the evaluation result false, it is returned an error. This interface

--- a/sdk/evaluator.go
+++ b/sdk/evaluator.go
@@ -73,7 +73,7 @@ func (e evaluator) EvaluateRequestPolicy(ctx context.Context, rondInput core.Inp
 	}
 	logger := options.GetLogger()
 
-	regoInput, err := core.CreateRegoQueryInput(logger, rondInput, core.RegoInputOptions{
+	evalInput, err := core.CreateRegoQueryInput(logger, rondInput, core.RegoInputOptions{
 		EnableResourcePermissionsMapOptimization: rondConfig.Options.EnableResourcePermissionsMapOptimization,
 	})
 	if err != nil {
@@ -82,7 +82,7 @@ func (e evaluator) EvaluateRequestPolicy(ctx context.Context, rondInput core.Inp
 
 	opaEvaluatorOptions := e.evaluatorOptions.opaEvaluatorOptions(logger)
 
-	evaluatorAllowPolicy, err := e.partialResultEvaluators.GetEvaluatorFromPolicy(ctx, rondConfig.RequestFlow.PolicyName, regoInput, opaEvaluatorOptions)
+	evaluatorAllowPolicy, err := e.partialResultEvaluators.GetEvaluatorFromPolicy(ctx, rondConfig.RequestFlow.PolicyName, opaEvaluatorOptions)
 	if err != nil {
 		return PolicyResult{}, err
 	}
@@ -90,7 +90,7 @@ func (e evaluator) EvaluateRequestPolicy(ctx context.Context, rondInput core.Inp
 	// TODO: here if the evaluation result false, it is returned an error. This interface
 	// for the sdk should be improved, since it should use the PolicyResult and return error
 	// only if there is some error in policy evaluation.
-	_, query, err := evaluatorAllowPolicy.PolicyEvaluation(logger, e.policyEvaluationOptions)
+	_, query, err := evaluatorAllowPolicy.PolicyEvaluation(logger, evalInput, e.policyEvaluationOptions)
 
 	if err != nil {
 		logger.WithField("error", map[string]any{
@@ -124,7 +124,7 @@ func (e evaluator) EvaluateResponsePolicy(ctx context.Context, rondInput core.In
 	}
 	logger := options.GetLogger()
 
-	regoInput, err := core.CreateRegoQueryInput(logger, rondInput, core.RegoInputOptions{
+	evalInput, err := core.CreateRegoQueryInput(logger, rondInput, core.RegoInputOptions{
 		EnableResourcePermissionsMapOptimization: rondConfig.Options.EnableResourcePermissionsMapOptimization,
 	})
 	if err != nil {
@@ -133,12 +133,12 @@ func (e evaluator) EvaluateResponsePolicy(ctx context.Context, rondInput core.In
 
 	opaEvaluatorOptions := e.evaluatorOptions.opaEvaluatorOptions(logger)
 
-	evaluator, err := e.partialResultEvaluators.GetEvaluatorFromPolicy(ctx, e.rondConfig.ResponseFlow.PolicyName, regoInput, opaEvaluatorOptions)
+	evaluator, err := e.partialResultEvaluators.GetEvaluatorFromPolicy(ctx, e.rondConfig.ResponseFlow.PolicyName, opaEvaluatorOptions)
 	if err != nil {
 		return nil, err
 	}
 
-	bodyToProxy, err := evaluator.Evaluate(logger, e.policyEvaluationOptions)
+	bodyToProxy, err := evaluator.Evaluate(logger, evalInput, e.policyEvaluationOptions)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR will improve performance of query generation of more than x20, and it seems also the allow and response.

Here the before/after on my machine:

Before: 

```
BenchmarkEvaluateRequest-10                                 4534            255834 ns/op          194671 B/op       3024 allocs/op
BenchmarkEvaluateRequestWithQueryGeneration-10               154           7485473 ns/op         4507957 B/op     112217 allocs/op
BenchmarkEvaluateResponse-10                                1639            702470 ns/op          486613 B/op       7980 allocs/op
```

After:

```
BenchmarkEvaluateRequest-10                                 5054            208840 ns/op          165831 B/op       2437 allocs/op
BenchmarkEvaluateRequestWithQueryGeneration-10              3505            339451 ns/op          241816 B/op       4309 allocs/op
BenchmarkEvaluateResponse-10                                2014            576589 ns/op          418976 B/op       6992 allocs/op
```