### PR TITLE
fix: conflicting policy configuration

### DIFF
--- a/mocks/config-with-conflicting-policy.json
+++ b/mocks/config-with-conflicting-policy.json
@@ -25,6 +25,20 @@
           }
         }
       }
+    },
+    "/some-api/:id/another": {
+      "get": {
+        "x-permission": {
+          "allow": "filter_policy_with_conflicting_configuration"
+        }
+      }
+    },
+    "/some-api/:id/another/deeper": {
+      "get": {
+        "x-permission": {
+          "allow": "filter_policy_with_conflicting_configuration"
+        }
+      }
     }
   }
 }

--- a/mocks/config-with-conflicting-policy.json
+++ b/mocks/config-with-conflicting-policy.json
@@ -1,0 +1,30 @@
+{
+  "paths": {
+    "/some-api/": {
+      "get": {
+        "x-permission": {
+          "allow": "filter_policy_with_conflicting_configuration",
+          "resourceFilter": {
+            "rowFilter": {
+              "enabled": true,
+              "headerKey": ""
+            }
+          }
+        }
+      }
+    },
+    "/some-api/:id": {
+      "get": {
+        "x-permission": {
+          "allow": "filter_policy_with_conflicting_configuration",
+          "resourceFilter": {
+            "rowFilter": {
+              "enabled": false,
+              "headerKey": ""
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/mocks/rego-policies/example.rego
+++ b/mocks/rego-policies/example.rego
@@ -100,3 +100,23 @@ projection_policy_with_audit_data[res] {
     set_audit_labels(z)
     res := input.response.body
 }
+
+filter_policy_with_conflicting_configuration {
+	query := data.resources[_]
+	binding := input.user.bindings[_]
+	query.companyId = binding.resource.resourceId
+}
+
+filter_policy_with_conflicting_configuration {
+	query := data.resources[_]
+	binding := input.user.bindings[_]
+	query.projectId = binding.resource.resourceId
+}
+
+filter_policy_with_conflicting_configuration {
+	query := data.resources[_]
+	resource_type_qs := object.get(input, ["request", "query", "some-qs", 0], false)
+	resource_type_qs == "some_qs"
+
+	query.resourceType = "some_qs"
+}


### PR DESCRIPTION
Proof-of-concept for #424 with a flaky test: two subsequent runs without code changes.

```bash
➜  rond git:(fix/conflicting-policy-configuration) ✗ go test . -v -run TestIntegrationConflictingPolicyConfiguration -count=1
=== RUN   TestIntegrationConflictingPolicyConfiguration
=== RUN   TestIntegrationConflictingPolicyConfiguration/200_-_works
    main_test.go:1630: Connection to localhost MongoDB, on CI env this is a problem!
--- PASS: TestIntegrationConflictingPolicyConfiguration (0.03s)
    --- PASS: TestIntegrationConflictingPolicyConfiguration/200_-_works (0.03s)
PASS
ok      github.com/rond-authz/rond      0.498s
➜  rond git:(fix/conflicting-policy-configuration) ✗ go test . -v -run TestIntegrationConflictingPolicyConfiguration -count=1
=== RUN   TestIntegrationConflictingPolicyConfiguration
=== RUN   TestIntegrationConflictingPolicyConfiguration/200_-_works
    main_test.go:1630: Connection to localhost MongoDB, on CI env this is a problem!
    main_test.go:1639: 
                Error Trace:    /Users/federicomaggi/Development/github.com/rond-authz/rond/main_test.go:1639
                Error:          Not equal: 
                                expected: 200
                                actual  : 403
                Test:           TestIntegrationConflictingPolicyConfiguration/200_-_works
--- FAIL: TestIntegrationConflictingPolicyConfiguration (0.03s)
    --- FAIL: TestIntegrationConflictingPolicyConfiguration/200_-_works (0.03s)
FAIL
FAIL    github.com/rond-authz/rond      0.493s
FAIL
```