### PR TITLE
fix: make audit config file optional

### DIFF
--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -61,7 +61,7 @@ type EnvironmentVariables struct {
 	ExposeMetrics                  bool   `env:"EXPOSE_METRICS" envDefault:"true"`
 
 	EnableAuditTrail                  bool     `env:"ENABLE_AUDIT_TRAIL"`
-	AuditConfigPath                   string   `env:"AUDIT_CONFIG_FILE_PATH" envDefault:"/app/config/audit_config.json"`
+	AuditConfigPath                   string   `env:"AUDIT_CONFIG_FILE_PATH"`
 	AuditAggregationIDHeaderName      string   `env:"AUDIT_AGGREGATION_ID_HEADER_NAME" envDefault:"x-request-id"`
 	AuditTargetServiceName            string   `env:"TARGET_SERVICE_NAME"`
 	AuditStorageMode                  []string `env:"AUDIT_STORAGE_MODE" envDefault:"log"`

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -85,7 +85,6 @@ func TestGetEnvOrDie(t *testing.T) {
 		MongoDBConnectionMaxIdleTimeMs:    1000,
 		AuditAggregationIDHeaderName:      "x-request-id",
 		AuditStorageMongoDBCollectionName: "audittrails",
-		AuditConfigPath:                   "/app/config/audit_config.json",
 	}
 
 	t.Run(`returns correctly - with TargetServiceHost`, func(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -225,7 +225,7 @@ func setupService(env config.EnvironmentVariables, log *logrus.Logger) (*app, er
 	}
 
 	var auditConfig audit.Config
-	if env.EnableAuditTrail {
+	if env.EnableAuditTrail && env.AuditConfigPath != "" {
 		auditConfig, err = audit.LoadConfiguration(env.AuditConfigPath)
 		if err != nil {
 			log.WithFields(logrus.Fields{


### PR DESCRIPTION
configuration file read is based on env presence, whose default value has been removed